### PR TITLE
Renovate improvements

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
     "extends": [
         "config:recommended"
     ],
+    "prHourlyLimit": 0,
     "repositories": [
         "stackitcloud/stackit-sdk-go"
     ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,9 @@
     "extends": [
         "config:recommended"
     ],
+    "ignorePresets": [
+        ":ignoreModulesAndTests"
+    ],
     "prHourlyLimit": 0,
     "repositories": [
         "stackitcloud/stackit-sdk-go"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:recommended",
-        ":dependencyDashboard"
+        "config:recommended"
     ],
     "repositories": [
         "stackitcloud/stackit-sdk-go"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,7 +14,12 @@
         "gomod",
         "github-actions"
     ],
-    "postUpdateOptions": [
-        "gomodTidy"
-    ]
+    "allowedPostUpgradeCommands": [
+        "^cd .* && make sync-tidy$"
+    ],
+    "postUpgradeTasks": {
+        "commands": [
+            "cd $(git rev-parse --show-toplevel) && make sync-tidy"
+        ]
+    }
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -6,7 +6,7 @@
     "ignorePresets": [
         ":ignoreModulesAndTests"
     ],
-    "prHourlyLimit": 0,
+    "prHourlyLimit": 10,
     "repositories": [
         "stackitcloud/stackit-sdk-go"
     ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,9 @@
         ":ignoreModulesAndTests"
     ],
     "prHourlyLimit": 10,
+    "labels": [
+        "renovate"
+    ],
     "repositories": [
         "stackitcloud/stackit-sdk-go"
     ],


### PR DESCRIPTION
- Remove redundant setting
- Renovate now finds go.mods of examples
- Add hourly limit
- Add PR label
- Add post task to run make sync-tidy