### PR TITLE
Add SetToken() to KeyFlow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@v39.1.0
+        uses: renovatebot/github-action@v39.1.1
         with:
           configurationFile: .github/renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}

--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -150,6 +150,19 @@ func KeyAuth(cfg *config.Configuration) (http.RoundTripper, error) {
 		return nil, fmt.Errorf("configuring key authentication: private key could not be found: %w", err)
 	}
 
+	if cfg.TokenCustomUrl == "" {
+		tokenCustomUrl, tokenUrlSet := os.LookupEnv("STACKIT_TOKEN_BASEURL")
+		if tokenUrlSet {
+			cfg.TokenCustomUrl = tokenCustomUrl
+		}
+	}
+	if cfg.JWKSCustomUrl == "" {
+		jwksCustomUrl, jwksUrlSet := os.LookupEnv("STACKIT_JWKS_BASEURL")
+		if jwksUrlSet {
+			cfg.JWKSCustomUrl = jwksCustomUrl
+		}
+	}
+
 	keyCfg := clients.KeyFlowConfig{
 		ServiceAccountKey: cfg.ServiceAccountKey,
 		PrivateKey:        cfg.PrivateKey,

--- a/core/clients/key_flow.go
+++ b/core/clients/key_flow.go
@@ -9,7 +9,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -25,10 +24,11 @@ const (
 	PrivateKey            = "STACKIT_PRIVATE_KEY"
 	ServiceAccountKeyPath = "STACKIT_SERVICE_ACCOUNT_KEY_PATH"
 	PrivateKeyPath        = "STACKIT_PRIVATE_KEY_PATH"
+	tokenAPI              = "https://service-account.api.stackit.cloud/token" //nolint:gosec // linter false positive
+	jwksAPI               = "https://service-account.api.stackit.cloud/.well-known/jwks.json"
+	defaultTokenType      = "Bearer"
+	defaultScope          = ""
 )
-
-var tokenAPI = "https://service-account.api.stackit.cloud/token" //nolint:gosec // linter false positive
-var jwksAPI = "https://service-account.api.stackit.cloud/.well-known/jwks.json"
 
 // KeyFlow handles auth with SA key
 type KeyFlow struct {
@@ -108,27 +108,43 @@ func (c *KeyFlow) Init(cfg *KeyFlowConfig) error {
 	c.token = &TokenResponseBody{}
 	c.config = cfg
 	c.doer = do
+
+	// set defaults if no custom token and jwks url are provided
 	if c.config.TokenUrl == "" {
-		tokenCustomUrl, tokenUrlSet := os.LookupEnv("STACKIT_TOKEN_BASEURL")
-		if !tokenUrlSet || tokenCustomUrl == "" {
-			c.config.TokenUrl = tokenAPI
-		} else {
-			c.config.TokenUrl = tokenCustomUrl
-		}
+		c.config.TokenUrl = tokenAPI
 	}
 	if c.config.JWKSUrl == "" {
-		jwksCustomUrl, jwksUrlSet := os.LookupEnv("STACKIT_JWKS_BASEURL")
-		if !jwksUrlSet || jwksCustomUrl == "" {
-			c.config.JWKSUrl = jwksAPI
-		} else {
-			c.config.TokenUrl = jwksCustomUrl
-		}
+		c.config.JWKSUrl = jwksAPI
 	}
 	c.configureHTTPClient()
 	if c.config.ClientRetry == nil {
 		c.config.ClientRetry = NewRetryConfig()
 	}
 	return c.validate()
+}
+
+// SetToken can be used to set an access and refresh token manually in the client
+// the other fields in the token field are determined by inspecting the token or setting default values
+func (c *KeyFlow) SetToken(accessToken, refreshToken string) error {
+	// We can safely use ParseUnverified because we are not authenticating the user,
+	// We are parsing the token just to get the expiration time claim
+	parsedAccessToken, _, err := jwt.NewParser().ParseUnverified(accessToken, &jwt.RegisteredClaims{})
+	if err != nil {
+		return fmt.Errorf("parse access token to read expiration time: %w", err)
+	}
+	exp, err := parsedAccessToken.Claims.GetExpirationTime()
+	if err != nil {
+		return fmt.Errorf("get expiration time from access token: %w", err)
+	}
+
+	c.token = &TokenResponseBody{
+		AccessToken:  accessToken,
+		ExpiresIn:    int(exp.Time.Unix()),
+		Scope:        defaultScope,
+		RefreshToken: refreshToken,
+		TokenType:    defaultTokenType,
+	}
+	return nil
 }
 
 // Clone creates a clone of the client

--- a/core/clients/key_flow_test.go
+++ b/core/clients/key_flow_test.go
@@ -146,11 +146,13 @@ func TestSetToken(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			var accessToken string
 			var err error
+
+			timestamp := time.Now().Add(24 * time.Hour)
 			if tt.tokenInvalid {
 				accessToken = "foo"
 			} else {
 				accessTokenJWT := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.RegisteredClaims{
-					ExpiresAt: jwt.NewNumericDate(time.Now().Add(24 * time.Hour))})
+					ExpiresAt: jwt.NewNumericDate(timestamp)})
 				accessToken, err = accessTokenJWT.SignedString(testSigningKey)
 				if err != nil {
 					t.Fatalf("get test access token as string: %s", err)
@@ -166,7 +168,7 @@ func TestSetToken(t *testing.T) {
 			if err == nil {
 				expectedKeyFlowToken := &TokenResponseBody{
 					AccessToken:  accessToken,
-					ExpiresIn:    int(time.Now().Add(24 * time.Hour).Unix()),
+					ExpiresIn:    int(timestamp.Unix()),
 					RefreshToken: tt.refreshToken,
 					Scope:        defaultScope,
 					TokenType:    defaultTokenType,


### PR DESCRIPTION
Support Authentication in the CLI:
- Reading custom token and jwks endpoints from env var is moved to the auth pkg
- Add SetToken to KeyFlow to allow setting the tokens directly