### PR TITLE
Deprecate `config.WithCaptureHTTPResponse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - `core`: [v0.y.z]
 - **Feature:** Add package `runtime`, which implements methods to be used when performing API requests
 - **Feature:** Add method `WithCaptureHTTPResponse` to package `runtime`, which does the same as `config.WithCaptureHTTPResponse`. Method was moved to avoid confusion due to it not being a configuration option, and will be removed in a later release.
+- **Deprecation:** Mark method `config.WithCaptureHTTPResponse` as deprecated, to avoid confusion due to it not being a configuration option. Use `runtime.WithCaptureHTTPResponse` instead.
 
 ## Release (2024-02-07)
 

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.9.0 (YYYY-MM-DD)
+
+- **Deprecation:** Mark method `config.WithCaptureHTTPResponse` as deprecated, to avoid confusion due to it not being a configuration option. Use `runtime.WithCaptureHTTPResponse` instead.
+
 ## v0.8.0 (2024-02-16)
 
 - **Feature:** Add package `runtime`, which implements methods to be used when performing API requests

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -310,6 +310,8 @@ func WithCustomConfiguration(cfg *Configuration) ConfigurationOption {
 
 // WithCaptureHTTPResponse adds the raw HTTP response retrieval annotation to the parent context.
 // The resp parameter will contain the raw HTTP response after the request has completed.
+//
+// Deprecated: Use runtime.WithCaptureHTTPResponse instead
 func WithCaptureHTTPResponse(parent context.Context, resp **http.Response) context.Context {
 	return context.WithValue(parent, ContextHTTPResponse, resp)
 }

--- a/examples/httpresponse/go.mod
+++ b/examples/httpresponse/go.mod
@@ -3,8 +3,8 @@ module github.com/stackitcloud/stackit-sdk-go/examples/httpresponse
 go 1.18
 
 require (
-	github.com/stackitcloud/stackit-sdk-go/core v0.7.7
-	github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v0.11.0
+	github.com/stackitcloud/stackit-sdk-go/core v0.8.0
+	github.com/stackitcloud/stackit-sdk-go/services/postgresflex v0.9.1
 )
 
 require (

--- a/examples/httpresponse/go.sum
+++ b/examples/httpresponse/go.sum
@@ -12,10 +12,10 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/stackitcloud/stackit-sdk-go/core v0.7.7 h1:w1T8I2ERT5xPHXS+UV9maSseK8tyUJQjzS21hhRSWjU=
-github.com/stackitcloud/stackit-sdk-go/core v0.7.7/go.mod h1:nfC2Tbjd73Ivn8wEp3lvG/dmiXHgl6QX+HY2Ih3aGgw=
-github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v0.11.0 h1:Ys1WYHlM/5ev5WmM3Qn/FboIlKeXbQSOU2PYlMQ2C9A=
-github.com/stackitcloud/stackit-sdk-go/services/mongodbflex v0.11.0/go.mod h1:n9bUnjBIAvpnyC5oNGFZKZ/mmoA9y7CBTFwi1KV62GA=
+github.com/stackitcloud/stackit-sdk-go/core v0.8.0 h1:oczQLvaeM3nGMqkWIw1a9sfc7lAzCauFjGQKjpJZpbg=
+github.com/stackitcloud/stackit-sdk-go/core v0.8.0/go.mod h1:UQ2I6MucPu7kggBWjlAP8H13sflwPUikuskH9s5SXKc=
+github.com/stackitcloud/stackit-sdk-go/services/postgresflex v0.9.1 h1:41M0IWsHFmt2KvoY/4vwWYNG94Tx3U3diSlYdz0thJE=
+github.com/stackitcloud/stackit-sdk-go/services/postgresflex v0.9.1/go.mod h1:bVXMSjQH1eGUF5IoPAD8BjAzhRMunDlnrwLsaCPgRQ4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.21.0 h1:AQyQV4dYCvJ7vGmJyKki9+PBdyvhkSd8EIx/qb0AYv4=

--- a/examples/httpresponse/httpresponse.go
+++ b/examples/httpresponse/httpresponse.go
@@ -7,7 +7,8 @@ import (
 	"os"
 
 	"github.com/stackitcloud/stackit-sdk-go/core/config"
-	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
+	"github.com/stackitcloud/stackit-sdk-go/core/runtime"
+	"github.com/stackitcloud/stackit-sdk-go/services/postgresflex"
 )
 
 func main() {
@@ -15,7 +16,7 @@ func main() {
 	projectId := "PROJECT_ID"
 
 	// Create a new API client, that uses default authentication and configuration
-	mongodbflexClient, err := mongodbflex.NewAPIClient(
+	postgresflexClient, err := postgresflex.NewAPIClient(
 		config.WithRegion("eu01"),
 	)
 	if err != nil {
@@ -25,10 +26,10 @@ func main() {
 
 	// Get the MongoDB Flex instances for your project and capture the HTTP response using the context
 	var httpResp *http.Response
-	ctxWithHTTPResp := config.WithCaptureHTTPResponse(context.Background(), &httpResp)
-	getInstancesResp, err := mongodbflexClient.ListInstances(ctxWithHTTPResp, projectId).Tag("tag").Execute()
+	ctxWithHTTPResp := runtime.WithCaptureHTTPResponse(context.Background(), &httpResp)
+	getInstancesResp, err := postgresflexClient.ListInstances(ctxWithHTTPResp, projectId).Execute()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error when calling `GetInstances`: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Error when calling `ListInstances`: %v\n", err)
 		os.Exit(1)
 	}
 	fmt.Printf("Number of instances: %v\n\n", len(*getInstancesResp.Items))


### PR DESCRIPTION
Changed from MongoDBFlex to PostgresFlex in example so it's simpler to follow (doesn't require the `Tag()` call)