### PR TITLE
Undo removal of `JWKSCustomUrl` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - **Feature:** Add package `runtime`, which implements methods to be used when performing API requests.
 - **Feature:** Add method `WithCaptureHTTPResponse` to package `runtime`, which does the same as `config.WithCaptureHTTPResponse`. Method was moved to avoid confusion due to it not being a configuration option, and will be removed in a later release.
 - **Deprecation:** Mark method `config.WithCaptureHTTPResponse` as deprecated, to avoid confusion due to it not being a configuration option. Use `runtime.WithCaptureHTTPResponse` instead.
-- **Deprecation:** Mark method `config.WithJWKSEndpoint` as deprecated. Validation using JWKS was removed, for being redundant with token validation done in the APIs. This option has no effect.
+- **Deprecation:** Mark method `config.WithJWKSEndpoint` and field `config.Configuration.JWKSCustomUrl` as deprecated. Validation using JWKS was removed, for being redundant with token validation done in the APIs. These have no effect.
 - **Breaking Change:** Remove method `KeyFlow.Clone`, that was no longer being used.
 
 ## Release (2024-02-07)

--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## v0.9.0 (YYYY-MM-DD)
 
 - **Deprecation:** Mark method `config.WithCaptureHTTPResponse` as deprecated, to avoid confusion due to it not being a configuration option. Use `runtime.WithCaptureHTTPResponse` instead.
-- **Deprecation:** Mark method `config.WithJWKSEndpoint` as deprecated. Validation using JWKS was removed, for being redundant with token validation done in the APIs. This option has no effect.
+- **Deprecation:** Mark method `config.WithJWKSEndpoint` and field `config.Configuration.JWKSCustomUrl` as deprecated. Validation using JWKS was removed, for being redundant with token validation done in the APIs. These have no effect.
 - **Breaking Change:** Remove method `KeyFlow.Clone`, that was no longer being used.
 
 ## v0.8.0 (2024-02-16)

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -78,14 +78,15 @@ type Configuration struct {
 	PrivateKeyPath        string            `json:"privateKeyPath,omitempty"`
 	CredentialsFilePath   string            `json:"credentialsFilePath,omitempty"`
 	TokenCustomUrl        string            `json:"tokenCustomUrl,omitempty"`
+	Region                string            `json:"region,omitempty"`
+	CustomAuth            http.RoundTripper
+	Servers               ServerConfigurations
+	OperationServers      map[string]ServerConfigurations
+	HTTPClient            *http.Client
+	RetryOptions          *clients.RetryConfig
+
 	// Deprecated: validation using JWKS was removed, for being redundant with token validation done in the APIs. This field has no effect, and will be removed in a later update
-	JWKSCustomUrl    string `json:"jwksCustomUrl,omitempty"`
-	Region           string `json:"region,omitempty"`
-	CustomAuth       http.RoundTripper
-	Servers          ServerConfigurations
-	OperationServers map[string]ServerConfigurations
-	HTTPClient       *http.Client
-	RetryOptions     *clients.RetryConfig
+	JWKSCustomUrl string `json:"jwksCustomUrl,omitempty"`
 
 	setCustomEndpoint bool
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -78,7 +78,7 @@ type Configuration struct {
 	PrivateKeyPath        string            `json:"privateKeyPath,omitempty"`
 	CredentialsFilePath   string            `json:"credentialsFilePath,omitempty"`
 	TokenCustomUrl        string            `json:"tokenCustomUrl,omitempty"`
-	// Deprecated: validation using JWKS was removed, for being redundant with token validation done in the APIs. This option has no effect, and will be removed in a later update
+	// Deprecated: validation using JWKS was removed, for being redundant with token validation done in the APIs. This field has no effect, and will be removed in a later update
 	JWKSCustomUrl    string `json:"jwksCustomUrl,omitempty"`
 	Region           string `json:"region,omitempty"`
 	CustomAuth       http.RoundTripper

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -78,12 +78,14 @@ type Configuration struct {
 	PrivateKeyPath        string            `json:"privateKeyPath,omitempty"`
 	CredentialsFilePath   string            `json:"credentialsFilePath,omitempty"`
 	TokenCustomUrl        string            `json:"tokenCustomUrl,omitempty"`
-	Region                string            `json:"region,omitempty"`
-	CustomAuth            http.RoundTripper
-	Servers               ServerConfigurations
-	OperationServers      map[string]ServerConfigurations
-	HTTPClient            *http.Client
-	RetryOptions          *clients.RetryConfig
+	// Deprecated: validation using JWKS was removed, for being redundant with token validation done in the APIs. This option has no effect, and will be removed in a later update
+	JWKSCustomUrl    string `json:"jwksCustomUrl,omitempty"`
+	Region           string `json:"region,omitempty"`
+	CustomAuth       http.RoundTripper
+	Servers          ServerConfigurations
+	OperationServers map[string]ServerConfigurations
+	HTTPClient       *http.Client
+	RetryOptions     *clients.RetryConfig
 
 	setCustomEndpoint bool
 }


### PR DESCRIPTION
Would cause a breaking change in next release
Marked as deprecated instead