### PR TITLE
Update ConfigureRegion for new global OAS server format

### DIFF
--- a/core/config/config.go
+++ b/core/config/config.go
@@ -13,6 +13,10 @@ import (
 	"github.com/stackitcloud/stackit-sdk-go/core/clients"
 )
 
+const (
+	global = "global"
+)
+
 // contextKeys are used to identify the type of value in the context.
 // Since these are string, it is possible to get a short description of the
 // context key for logging and debugging using key.String().
@@ -480,12 +484,12 @@ func ConfigureRegion(cfg *Configuration) error {
 	}
 
 	if cfg.Region == "" {
-		// Check token
+		// Check region
 		envVarRegion, _ := os.LookupEnv("STACKIT_REGION")
 		cfg.Region = envVarRegion
 	}
 
-	if oasRegion.DefaultValue != "" {
+	if oasRegion.DefaultValue != "" && oasRegion.DefaultValue != global {
 		if cfg.Region == "" {
 			return fmt.Errorf("no region was provided, available regions are: %s", availableRegions)
 		}
@@ -503,7 +507,9 @@ func ConfigureRegion(cfg *Configuration) error {
 		// Region is not available.
 		return fmt.Errorf("the provided region is not available for this API, available regions are: %s", availableRegions)
 	}
-	// Global API. The provided region is ignored
+	// Global API. The provided region is ignored.
+	// If the url is a template, generated using deprecated config.json, the region variable is replaced
+	// If the url is already configured, there is no region variable and it remains the same
 	cfgUrl := strings.Replace(servers[0].URL, "{region}", "", -1)
 	cfg.Servers = ServerConfigurations{
 		{

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -41,7 +41,7 @@ func TestConfigureRegion(t *testing.T) {
 			isValid: true,
 		},
 		{
-			desc: "valid_global",
+			desc: "valid_deprecated_global",
 			cfg: &Configuration{
 				Region: "",
 				Servers: ServerConfigurations{
@@ -65,7 +65,55 @@ func TestConfigureRegion(t *testing.T) {
 			isValid: true,
 		},
 		{
-			desc: "valid_global_with_specified_region",
+			desc: "valid_global_empty_default",
+			cfg: &Configuration{
+				Region: "",
+				Servers: ServerConfigurations{
+					ServerConfiguration{
+						URL: "https://some-api.api.stackit.cloud",
+						Variables: map[string]ServerVariable{
+							"region": {
+								DefaultValue: "",
+								EnumValues:   []string{},
+							},
+						},
+					},
+				},
+			},
+			regionEnvVar: "",
+			expectedServers: ServerConfigurations{
+				ServerConfiguration{
+					URL: "https://some-api.api.stackit.cloud",
+				},
+			},
+			isValid: true,
+		},
+		{
+			desc: "valid_global_default",
+			cfg: &Configuration{
+				Region: "",
+				Servers: ServerConfigurations{
+					ServerConfiguration{
+						URL: "https://some-api.api.stackit.cloud",
+						Variables: map[string]ServerVariable{
+							"region": {
+								DefaultValue: "global",
+								EnumValues:   []string{},
+							},
+						},
+					},
+				},
+			},
+			regionEnvVar: "",
+			expectedServers: ServerConfigurations{
+				ServerConfiguration{
+					URL: "https://some-api.api.stackit.cloud",
+				},
+			},
+			isValid: true,
+		},
+		{
+			desc: "valid_deprecated_global_with_specified_region",
 			cfg: &Configuration{
 				Region: "eu01",
 				Servers: ServerConfigurations{


### PR DESCRIPTION
With the migration to the stackit-api repo, the generated OAS for global APIs will have a different server url that follows this pattern:
```
"servers": [
    {
      "url": "https://identifier.api.stackit.cloud",
      "variables": {
        "region": {
          "default": "global"
        }
      }
    }
  ]
  ```
  
  This PR updates the ConfigureRegion method to take into account this change