### PR TITLE
Add waiters for server operations (start, stop, deallocate, rescue, unrescue)

### DIFF
--- a/examples/iaas/attach_nic/attach_nic.go
+++ b/examples/iaas/attach_nic/attach_nic.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/runtime"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas/wait"
+)
+
+func main() {
+	// Specify the organization ID and project ID
+	projectId := "PROJECT_ID"
+	serverId := "SERVER_ID"
+	nicId := "NIC_ID"
+
+	// Create a new API client, that uses default authentication and configuration
+	iaasClient, err := iaas.NewAPIClient(
+		config.WithRegion("eu01"),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Creating API client: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Attach an existing network interface to an existing server
+	var httpResp *http.Response
+	ctxWithHTTPResp := runtime.WithCaptureHTTPResponse(context.Background(), &httpResp)
+	err = iaasClient.AddNICToServer(ctxWithHTTPResp, projectId, serverId, nicId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `AddNICToServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered attachment of nic with ID %q.\n", nicId)
+	}
+	requestId := httpResp.Header[wait.XRequestIDHeader][0]
+
+	// Wait for attachment of the nic
+	_, err = wait.ProjectRequestWaitHandler(context.Background(), iaasClient, projectId, requestId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for attachment: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Nic %q has been successfully attached to the server %s.\n", nicId, serverId)
+
+	err = iaasClient.RemoveNICFromServer(ctxWithHTTPResp, projectId, serverId, nicId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `RemoveNICFromServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered removal of attachment of nic with ID %q.\n", nicId)
+	}
+
+	requestId = httpResp.Header[wait.XRequestIDHeader][0]
+
+	// Wait for dettachment of the nic
+	_, err = wait.ProjectRequestWaitHandler(context.Background(), iaasClient, projectId, requestId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for removal of attachment of NIC: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] NIC %q has been successfully detached from the server %s.\n", nicId, serverId)
+}

--- a/examples/iaas/attach_public_ip/attach_public_ip.go
+++ b/examples/iaas/attach_public_ip/attach_public_ip.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/runtime"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas/wait"
+)
+
+func main() {
+	// Specify the organization ID and project ID
+	projectId := "PROJECT_ID"
+	serverId := "SERVER_ID"
+	publicIpId := "PUBLIC_IP_ID"
+
+	// Create a new API client, that uses default authentication and configuration
+	iaasClient, err := iaas.NewAPIClient(
+		config.WithRegion("eu01"),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Creating API client: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Attach an existing network interface to an existing server
+	var httpResp *http.Response
+	ctxWithHTTPResp := runtime.WithCaptureHTTPResponse(context.Background(), &httpResp)
+	err = iaasClient.AddPublicIpToServer(ctxWithHTTPResp, projectId, serverId, publicIpId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `AddPublicIpToServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered attachment of public ip with ID %q.\n", publicIpId)
+	}
+	requestId := httpResp.Header[wait.XRequestIDHeader][0]
+
+	// Wait for attachment of the public ip
+	_, err = wait.ProjectRequestWaitHandler(context.Background(), iaasClient, projectId, requestId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for attachment: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Public IP %q has been successfully attached to the server %s.\n", publicIpId, serverId)
+
+	err = iaasClient.RemovePublicIpFromServer(ctxWithHTTPResp, projectId, serverId, publicIpId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `RemovePublicIpFromServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered removal of attachment of public ip with ID %q.\n", publicIpId)
+	}
+
+	requestId = httpResp.Header[wait.XRequestIDHeader][0]
+
+	// Wait for dettachment of the public ip
+	_, err = wait.ProjectRequestWaitHandler(context.Background(), iaasClient, projectId, requestId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for removal of attachment of PublicIp: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] PublicIp %q has been successfully detached from the server %s.\n", publicIpId, serverId)
+}

--- a/examples/iaas/attach_security_group/attach_security_group.go
+++ b/examples/iaas/attach_security_group/attach_security_group.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/runtime"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas/wait"
+)
+
+func main() {
+	// Specify the organization ID and project ID
+	projectId := "PROJECT_ID"
+	serverId := "SERVER_ID"
+	securityGroupId := "SECURITY_GROUP_ID"
+
+	// Create a new API client, that uses default authentication and configuration
+	iaasClient, err := iaas.NewAPIClient(
+		config.WithRegion("eu01"),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Creating API client: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Attach an existing network interface to an existing server
+	var httpResp *http.Response
+	ctxWithHTTPResp := runtime.WithCaptureHTTPResponse(context.Background(), &httpResp)
+	err = iaasClient.AddSecurityGroupToServer(ctxWithHTTPResp, projectId, serverId, securityGroupId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `AddSecurityGroupToServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered attachment of security group with ID %q.\n", securityGroupId)
+	}
+	requestId := httpResp.Header[wait.XRequestIDHeader][0]
+
+	// Wait for attachment of the security group
+	_, err = wait.ProjectRequestWaitHandler(context.Background(), iaasClient, projectId, requestId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for attachment: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Security group %q has been successfully attached to the server %s.\n", securityGroupId, serverId)
+
+	err = iaasClient.RemoveSecurityGroupFromServer(ctxWithHTTPResp, projectId, serverId, securityGroupId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `RemoveSecurityGroupFromServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered removal of attachment of security group with ID %q.\n", securityGroupId)
+	}
+
+	requestId = httpResp.Header[wait.XRequestIDHeader][0]
+
+	// Wait for dettachment of the security group
+	_, err = wait.ProjectRequestWaitHandler(context.Background(), iaasClient, projectId, requestId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for removal of attachment of SecurityGroup: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] SecurityGroup %q has been successfully detached from the server %s.\n", securityGroupId, serverId)
+}

--- a/examples/iaas/attach_service_account/attach_service_account.go
+++ b/examples/iaas/attach_service_account/attach_service_account.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/runtime"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas/wait"
+)
+
+func main() {
+	// Specify the organization ID and project ID
+	projectId := "PROJECT_ID"
+	serverId := "SERVER_ID"
+	serviceAccountMail := "SERVICE_ACCOUNT_MAIL"
+
+	// Create a new API client, that uses default authentication and configuration
+	iaasClient, err := iaas.NewAPIClient(
+		config.WithRegion("eu01"),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Creating API client: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Attach an existing service account to an existing server
+	var httpResp *http.Response
+	ctxWithHTTPResp := runtime.WithCaptureHTTPResponse(context.Background(), &httpResp)
+	_, err = iaasClient.AddServiceAccountToServer(ctxWithHTTPResp, projectId, serverId, serviceAccountMail).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `AddServiceAccountToServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered attachment of service account with mail %q.\n", serviceAccountMail)
+	}
+	requestId := httpResp.Header[wait.XRequestIDHeader][0]
+
+	// Wait for attachment of the service account
+	_, err = wait.ProjectRequestWaitHandler(context.Background(), iaasClient, projectId, requestId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for attachment: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Service account %q has been successfully attached to the server %s.\n", serviceAccountMail, serverId)
+
+	_, err = iaasClient.RemoveServiceAccountFromServer(ctxWithHTTPResp, projectId, serverId, serviceAccountMail).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `RemoveServiceAccountFromServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered removal of attachment of service account with mail %q.\n", serviceAccountMail)
+	}
+
+	requestId = httpResp.Header[wait.XRequestIDHeader][0]
+
+	// Wait for dettachment of the service account
+	_, err = wait.ProjectRequestWaitHandler(context.Background(), iaasClient, projectId, requestId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for removal of attachment of service account: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Service account %q has been successfully detached from the server %s.\n", serviceAccountMail, serverId)
+}

--- a/examples/iaas/attach_volume/attach_volume.go
+++ b/examples/iaas/attach_volume/attach_volume.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas/wait"
+)
+
+func main() {
+	// Specify the organization ID and project ID
+	projectId := "PROJECT_ID"
+	serverId := "SERVER_ID"
+	volumeId := "VOLUME_ID"
+
+	// Create a new API client, that uses default authentication and configuration
+	iaasClient, err := iaas.NewAPIClient(
+		config.WithRegion("eu01"),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Creating API client: %v\n", err)
+		os.Exit(1)
+	}
+
+	payload := iaas.AddVolumeToServerPayload{}
+	_, err = iaasClient.AddVolumeToServer(context.Background(), projectId, serverId, volumeId).AddVolumeToServerPayload(payload).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `AddVolumeToServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered attachment of volume with ID %q.\n", volumeId)
+	}
+
+	// Wait for attachment of the volume
+	_, err = wait.AddVolumeToServerWaitHandler(context.Background(), iaasClient, projectId, serverId, volumeId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for attachment: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Volume %q has been successfully attached to the server %s.\n", volumeId, serverId)
+
+	err = iaasClient.RemoveVolumeFromServer(context.Background(), projectId, serverId, volumeId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `RemoveVolumeFromServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered removal of attachment of volume with ID %q.\n", volumeId)
+	}
+
+	// Wait for dettachment of the volume
+	_, err = wait.RemoveVolumeFromServerWaitHandler(context.Background(), iaasClient, projectId, serverId, volumeId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for removal of attachment of volume: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Volume %q has been successfully detached from the server %s.\n", volumeId, serverId)
+}

--- a/examples/iaas/network/network.go
+++ b/examples/iaas/network/network.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas/wait"
+)
+
+func main() {
+	// Specify the organization ID and project ID
+	projectId := "PROJECT_ID"
+
+	// Create a new API client, that uses default authentication and configuration
+	iaasClient, err := iaas.NewAPIClient(
+		config.WithRegion("eu01"),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[IaaS API] Creating API client: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Create a network
+	createNetworkPayload := iaas.CreateNetworkPayload{
+		Name: utils.Ptr("example-network"),
+		AddressFamily: &iaas.CreateNetworkAddressFamily{
+			Ipv4: &iaas.CreateNetworkIPv4Body{
+				PrefixLength: utils.Ptr(int64(24)),
+				Nameservers:  &[]string{"1.2.3.4"},
+			},
+		},
+	}
+
+	network, err := iaasClient.CreateNetwork(context.Background(), projectId).CreateNetworkPayload(createNetworkPayload).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[IaaS API] Error when calling `CreateNetwork`: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[IaaS API] Triggered creation of network with ID %q.\n", *network.NetworkId)
+	fmt.Printf("[Iaas API] Current state of the network: %q\n", *network.State)
+	fmt.Println("[Iaas API] Waiting for network to be created...")
+
+	network, err = wait.CreateNetworkWaitHandler(context.Background(), iaasClient, projectId, *network.NetworkId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[IaaS API] Error when waiting for creation: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[IaaS API] Network has been successfully created.\n")
+
+	// Update a network
+	updateNetworkPayload := iaas.PartialUpdateNetworkPayload{
+		Name: utils.Ptr("example-network-test-renamed"),
+	}
+
+	err = iaasClient.PartialUpdateNetwork(context.Background(), projectId, *network.NetworkId).PartialUpdateNetworkPayload(updateNetworkPayload).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[IaaS API] Error when calling `PartialUpdateNetwork`: %v\n", err)
+		os.Exit(1)
+	}
+
+	_, err = wait.UpdateNetworkWaitHandler(context.Background(), iaasClient, projectId, *network.NetworkId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[IaaS API] Error when waiting for update: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[IaaS API] Network has been successfully updated.\n")
+
+	// Delete a network
+	err = iaasClient.DeleteNetwork(context.Background(), projectId, *network.NetworkId).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[IaaS API] Error when calling `DeleteNetwork`: %v\n", err)
+		os.Exit(1)
+	}
+
+	_, err = wait.DeleteNetworkWaitHandler(context.Background(), iaasClient, projectId, *network.NetworkId).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[IaaS API] Error when waiting for deletion: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[IaaS API] Network has been successfully deleted.\n")
+}

--- a/examples/iaas/network_area/network_area.go
+++ b/examples/iaas/network_area/network_area.go
@@ -14,7 +14,6 @@ import (
 func main() {
 	// Specify the organization ID and project ID
 	organizationId := "ORGANIZATION_ID"
-	projectId := "PROJECT_ID"
 
 	// Create a new API client, that uses default authentication and configuration
 	iaasClient, err := iaas.NewAPIClient(
@@ -104,67 +103,4 @@ func main() {
 	}
 
 	fmt.Printf("[IaaS API] Network area %q has been successfully deleted.\n", *updatedArea.AreaId)
-
-	// Create a network
-	createNetworkPayload := iaas.CreateNetworkPayload{
-		Name: utils.Ptr("example-network"),
-		AddressFamily: &iaas.CreateNetworkAddressFamily{
-			Ipv4: &iaas.CreateNetworkIPv4Body{
-				PrefixLength: utils.Ptr(int64(24)),
-				Nameservers:  &[]string{"1.2.3.4"},
-			},
-		},
-	}
-
-	network, err := iaasClient.CreateNetwork(context.Background(), projectId).CreateNetworkPayload(createNetworkPayload).Execute()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "[IaaS API] Error when calling `CreateNetwork`: %v\n", err)
-		os.Exit(1)
-	}
-
-	fmt.Printf("[IaaS API] Triggered creation of network with ID %q.\n", *network.NetworkId)
-	fmt.Printf("[Iaas API] Current state of the network: %q\n", *network.State)
-	fmt.Println("[Iaas API] Waiting for network to be created...")
-
-	network, err = wait.CreateNetworkWaitHandler(context.Background(), iaasClient, projectId, *network.NetworkId).WaitWithContext(context.Background())
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "[IaaS API] Error when waiting for creation: %v\n", err)
-		os.Exit(1)
-	}
-
-	fmt.Printf("[IaaS API] Network has been successfully created.\n")
-
-	// Update a network
-	updateNetworkPayload := iaas.PartialUpdateNetworkPayload{
-		Name: utils.Ptr("example-network-test-renamed"),
-	}
-
-	err = iaasClient.PartialUpdateNetwork(context.Background(), projectId, *network.NetworkId).PartialUpdateNetworkPayload(updateNetworkPayload).Execute()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "[IaaS API] Error when calling `PartialUpdateNetwork`: %v\n", err)
-		os.Exit(1)
-	}
-
-	_, err = wait.UpdateNetworkWaitHandler(context.Background(), iaasClient, projectId, *network.NetworkId).WaitWithContext(context.Background())
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "[IaaS API] Error when waiting for update: %v\n", err)
-		os.Exit(1)
-	}
-
-	fmt.Printf("[IaaS API] Network has been successfully updated.\n")
-
-	// Delete a network
-	err = iaasClient.DeleteNetwork(context.Background(), projectId, *network.NetworkId).Execute()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "[IaaS API] Error when calling `DeleteNetwork`: %v\n", err)
-		os.Exit(1)
-	}
-
-	_, err = wait.DeleteNetworkWaitHandler(context.Background(), iaasClient, projectId, *network.NetworkId).WaitWithContext(context.Background())
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "[IaaS API] Error when waiting for deletion: %v\n", err)
-		os.Exit(1)
-	}
-
-	fmt.Printf("[IaaS API] Network has been successfully deleted.\n")
 }

--- a/examples/iaas/publicip/publicIp.go
+++ b/examples/iaas/publicip/publicIp.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+)
+
+func main() {
+	// Specify the organization ID and project ID
+	projectId := "PROJECT_ID"
+
+	// Create a new API client, that uses default authentication and configuration
+	iaasClient, err := iaas.NewAPIClient(
+		config.WithRegion("eu01"),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Creating API client: %v\n", err)
+		os.Exit(1)
+	}
+
+	publicIps, err := iaasClient.ListPublicIPs(context.Background(), projectId).Execute()
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `ListPublicIPs`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Number of Public IPs: %v\n", len(*publicIps.Items))
+	}
+
+	// Create a publicIp
+	createpublicIpPayload := iaas.CreatePublicIPPayload{
+		NetworkInterface: iaas.NewNullableString(utils.Ptr("NIC_ID")),
+	}
+	publicIp, err := iaasClient.CreatePublicIP(context.Background(), projectId).CreatePublicIPPayload(createpublicIpPayload).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `CreatePublicIP`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] public IP %q has been successfully created.\n", *publicIp.Id)
+	}
+
+	// Update a publicIp
+	updatepublicIpPayload := iaas.UpdatePublicIPPayload{
+		NetworkInterface: iaas.NewNullableString(nil),
+	}
+	publicIp, err = iaasClient.UpdatePublicIP(context.Background(), projectId, *publicIp.Id).UpdatePublicIPPayload(updatepublicIpPayload).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `UpdatePublicIP`: %v\n", err)
+	}
+
+	fmt.Printf("[iaas API] public IP %q has been successfully updated.\n", *publicIp.Id)
+	if publicIp.NetworkInterface == nil {
+		fmt.Printf("[iaas API] Public IP network interface has been successfully removed.\n")
+	} else {
+		fmt.Fprintf(os.Stderr, "[iaas API] Public IP network interface has not been removed.\n")
+	}
+
+	// Delete a public IP
+	err = iaasClient.DeletePublicIP(context.Background(), projectId, *publicIp.Id).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `DeletepublicIp`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] public IP %q has been successfully deleted.\n", *publicIp.Id)
+	}
+}

--- a/examples/iaas/server/server.go
+++ b/examples/iaas/server/server.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas/wait"
+)
+
+func main() {
+	// Specify the organization ID and project ID
+	projectId := "PROJECT_ID"
+
+	// Create a new API client, that uses default authentication and configuration
+	iaasClient, err := iaas.NewAPIClient(
+		config.WithRegion("eu01"),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Creating API client: %v\n", err)
+		os.Exit(1)
+	}
+
+	servers, err := iaasClient.ListServers(context.Background(), projectId).Execute()
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `ListServers`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Number of servers: %v\n", len(*servers.Items))
+	}
+
+	// Create a server
+	createServerPayload := iaas.CreateServerPayload{
+		Name:             utils.Ptr("example-server"),
+		AvailabilityZone: utils.Ptr("eu01-1"),
+		MachineType:      utils.Ptr("g1.1"),
+		BootVolume: &iaas.CreateServerPayloadBootVolume{
+			Size: utils.Ptr(int64(64)),
+			Source: &iaas.BootVolumeSource{
+				Id:   utils.Ptr("IMAGE_ID"),
+				Type: utils.Ptr("image"),
+			},
+		},
+	}
+	server, err := iaasClient.CreateServer(context.Background(), projectId).CreateServerPayload(createServerPayload).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `CreateServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered creation of server with ID %q.\n", *server.Id)
+	}
+
+	// Wait for creation of the server
+	server, err = wait.CreateServerWaitHandler(context.Background(), iaasClient, projectId, *server.Id).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for creation: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Server %q has been successfully created.\n", *server.Id)
+
+	// Stop a server
+	err = iaasClient.StopServer(context.Background(), projectId, *server.Id).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `StopServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered stop of server with ID %q.\n", *server.Id)
+	}
+
+	// Wait for stop of the server
+	server, err = wait.StopServerWaitHandler(context.Background(), iaasClient, projectId, *server.Id).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for stop: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Server %q has been successfully stopped.\n", *server.Id)
+
+	// Start a server
+	err = iaasClient.StartServer(context.Background(), projectId, *server.Id).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `StartServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered start of server with ID %q.\n", *server.Id)
+	}
+
+	// Wait for start of the server
+	server, err = wait.StartServerWaitHandler(context.Background(), iaasClient, projectId, *server.Id).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for start: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Server %q has been successfully started.\n", *server.Id)
+
+	// Update a server
+	updateServerPayload := iaas.UpdateServerPayload{
+		Name: utils.Ptr("renamed"),
+	}
+	server, err = iaasClient.UpdateServer(context.Background(), projectId, *server.Id).UpdateServerPayload(updateServerPayload).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `UpdateServer`: %v\n", err)
+	}
+
+	fmt.Printf("[iaas API] Server %q has been successfully updated.\n", *server.Id)
+
+	// Resize a server
+	resizeServerPayload := iaas.ResizeServerPayload{
+		MachineType: utils.Ptr("c1.2"),
+	}
+
+	err = iaasClient.ResizeServer(context.Background(), projectId, *server.Id).ResizeServerPayload(resizeServerPayload).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `ResizeServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered resize of server with ID %q.\n", *server.Id)
+	}
+
+	server, err = wait.ResizeServerWaitHandler(context.Background(), iaasClient, projectId, *server.Id).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for resize: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Server %q has been successfully resized.\n", *server.Id)
+
+	// Delete a server
+	err = iaasClient.DeleteServer(context.Background(), projectId, *server.Id).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `DeleteServer`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered deletion of server with ID %q.\n", *server.Id)
+	}
+
+	// Wait for deletion of the server
+	_, err = wait.DeleteServerWaitHandler(context.Background(), iaasClient, projectId, *server.Id).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for deletion: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Server %q has been successfully deleted.\n", *server.Id)
+}

--- a/examples/iaas/volume/volume.go
+++ b/examples/iaas/volume/volume.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/stackitcloud/stackit-sdk-go/core/config"
+	"github.com/stackitcloud/stackit-sdk-go/core/utils"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas"
+	"github.com/stackitcloud/stackit-sdk-go/services/iaas/wait"
+)
+
+func main() {
+	// Specify the organization ID and project ID
+	projectId := "PROJECT_ID"
+
+	// Create a new API client, that uses default authentication and configuration
+	iaasClient, err := iaas.NewAPIClient(
+		config.WithRegion("eu01"),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Creating API client: %v\n", err)
+		os.Exit(1)
+	}
+
+	volumes, err := iaasClient.ListVolumes(context.Background(), projectId).Execute()
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `ListVolumes`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Number of volumes: %v\n", len(*volumes.Items))
+	}
+
+	// Create a volume
+	createVolumePayload := iaas.CreateVolumePayload{
+		Name:             utils.Ptr("example-volume"),
+		AvailabilityZone: utils.Ptr("eu01-1"),
+		Size:             utils.Ptr(int64(10)),
+	}
+	volume, err := iaasClient.CreateVolume(context.Background(), projectId).CreateVolumePayload(createVolumePayload).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `CreateVolume`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered creation of volume with ID %q.\n", *volume.Id)
+	}
+
+	// Wait for creation of the volume
+	volume, err = wait.CreateVolumeWaitHandler(context.Background(), iaasClient, projectId, *volume.Id).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for creation: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Volume %q has been successfully created.\n", *volume.Id)
+
+	// Update a volume
+	updateVolumePayload := iaas.UpdateVolumePayload{
+		Name: utils.Ptr("renamed"),
+	}
+	volume, err = iaasClient.UpdateVolume(context.Background(), projectId, *volume.Id).UpdateVolumePayload(updateVolumePayload).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `UpdateVolume`: %v\n", err)
+	}
+
+	fmt.Printf("[iaas API] Volume %q has been successfully updated.\n", *volume.Id)
+
+	// Resize a volume
+	resizeVolumePayload := iaas.ResizeVolumePayload{
+		Size: utils.Ptr(int64(130)),
+	}
+	err = iaasClient.ResizeVolume(context.Background(), projectId, *volume.Id).ResizeVolumePayload(resizeVolumePayload).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `ResizeVolume`: %v\n", err)
+	}
+
+	fmt.Printf("[iaas API] Volume %q has been successfully resized.\n", *volume.Id)
+
+	// Delete a volume
+	err = iaasClient.DeleteVolume(context.Background(), projectId, *volume.Id).Execute()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `DeleteVolume`: %v\n", err)
+	} else {
+		fmt.Printf("[iaas API] Triggered deletion of volume with ID %q.\n", *volume.Id)
+	}
+
+	// Wait for deletion of the volume
+	_, err = wait.DeleteVolumeWaitHandler(context.Background(), iaasClient, projectId, *volume.Id).WaitWithContext(context.Background())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for deletion: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("[iaas API] Volume %q has been successfully deleted.\n", *volume.Id)
+}

--- a/services/iaas/wait/wait.go
+++ b/services/iaas/wait/wait.go
@@ -15,9 +15,14 @@ const (
 	CreateSuccess         = "CREATED"
 	VolumeAvailableStatus = "AVAILABLE"
 	DeleteSuccess         = "DELETED"
-	ErrorStatus           = "ERROR"
-	ServerActiveStatus    = "ACTIVE"
-	ServerResizingStatus  = "RESIZING"
+
+	ErrorStatus = "ERROR"
+
+	ServerActiveStatus      = "ACTIVE"
+	ServerResizingStatus    = "RESIZING"
+	ServerInactiveStatus    = "INACTIVE"
+	ServerDeallocatedStatus = "DEALLOCATED"
+	ServerRescueStatus      = "RESCUE"
 
 	RequestCreateAction  = "CREATE"
 	RequestUpdateAction  = "UPDATE"
@@ -298,6 +303,131 @@ func DeleteServerWaitHandler(ctx context.Context, a APIClientInterface, projectI
 			return false, server, err
 		}
 		return true, nil, nil
+	})
+	handler.SetTimeout(20 * time.Minute)
+	return handler
+}
+
+// StartServerWaitHandler will wait for server start
+func StartServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, serverId string) *wait.AsyncActionHandler[iaas.Server] {
+	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
+		server, err := a.GetServerExecute(ctx, projectId, serverId)
+		if err != nil {
+			return false, server, err
+		}
+		if server.Id == nil || server.Status == nil {
+			return false, server, fmt.Errorf("start failed for server with id %s, the response is not valid: the id or the status are missing", serverId)
+		}
+		if *server.Id == serverId && *server.Status == ServerActiveStatus {
+			return true, server, nil
+		}
+		if *server.Id == serverId && *server.Status == ErrorStatus {
+			if server.ErrorMessage != nil {
+				return true, server, fmt.Errorf("start failed for server with id %s: %s", serverId, *server.ErrorMessage)
+			}
+			return true, server, fmt.Errorf("start failed for server with id %s", serverId)
+		}
+		return false, server, nil
+	})
+	handler.SetTimeout(20 * time.Minute)
+	return handler
+}
+
+// StopServerWaitHandler will wait for server stop
+func StopServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, serverId string) *wait.AsyncActionHandler[iaas.Server] {
+	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
+		server, err := a.GetServerExecute(ctx, projectId, serverId)
+		if err != nil {
+			return false, server, err
+		}
+		if server.Id == nil || server.Status == nil {
+			return false, server, fmt.Errorf("stop failed for server with id %s, the response is not valid: the id or the status are missing", serverId)
+		}
+		if *server.Id == serverId && *server.Status == ServerInactiveStatus {
+			return true, server, nil
+		}
+		if *server.Id == serverId && *server.Status == ErrorStatus {
+			if server.ErrorMessage != nil {
+				return true, server, fmt.Errorf("stop failed for server with id %s: %s", serverId, *server.ErrorMessage)
+			}
+			return true, server, fmt.Errorf("stop failed for server with id %s", serverId)
+		}
+		return false, server, nil
+	})
+	handler.SetTimeout(20 * time.Minute)
+	return handler
+}
+
+// DeallocateServerWaitHandler will wait for server deallocation
+func DeallocateServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, serverId string) *wait.AsyncActionHandler[iaas.Server] {
+	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
+		server, err := a.GetServerExecute(ctx, projectId, serverId)
+		if err != nil {
+			return false, server, err
+		}
+		if server.Id == nil || server.Status == nil {
+			return false, server, fmt.Errorf("deallocate failed for server with id %s, the response is not valid: the id or the status are missing", serverId)
+		}
+		if *server.Id == serverId && *server.Status == ServerDeallocatedStatus {
+			return true, server, nil
+		}
+		if *server.Id == serverId && *server.Status == ErrorStatus {
+			if server.ErrorMessage != nil {
+				return true, server, fmt.Errorf("deallocate failed for server with id %s: %s", serverId, *server.ErrorMessage)
+			}
+			return true, server, fmt.Errorf("deallocate failed for server with id %s", serverId)
+		}
+		return false, server, nil
+	})
+	handler.SetTimeout(20 * time.Minute)
+	return handler
+}
+
+// RescueServerWaitHandler will wait for server rescue
+func RescueServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, serverId string) *wait.AsyncActionHandler[iaas.Server] {
+	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
+		server, err := a.GetServerExecute(ctx, projectId, serverId)
+		if err != nil {
+			return false, server, err
+		}
+		if server.Id == nil || server.Status == nil {
+			return false, server, fmt.Errorf("rescue failed for server with id %s, the response is not valid: the id or the status are missing", serverId)
+		}
+		if *server.Id == serverId && *server.Status == ServerRescueStatus {
+			return true, server, nil
+		}
+		if *server.Id == serverId && *server.Status == ErrorStatus {
+			if server.ErrorMessage != nil {
+				return true, server, fmt.Errorf("rescue failed for server with id %s: %s", serverId, *server.ErrorMessage)
+			}
+			return true, server, fmt.Errorf("rescue failed for server with id %s", serverId)
+		}
+		return false, server, nil
+	})
+	handler.SetTimeout(20 * time.Minute)
+	return handler
+}
+
+// UnrescueServerWaitHandler will wait for server unrescue
+func UnrescueServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, serverId string) *wait.AsyncActionHandler[iaas.Server] {
+	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
+		server, err := a.GetServerExecute(ctx, projectId, serverId)
+		if err != nil {
+			return false, server, err
+		}
+		if server.Id == nil || server.Status == nil {
+			return false, server, fmt.Errorf("unrescue failed for server with id %s, the response is not valid: the id or the status are missing", serverId)
+		}
+		if *server.Id == serverId && *server.Status == ServerActiveStatus {
+			return true, server, nil
+		}
+		if *server.Id == serverId && *server.Status == ErrorStatus {
+			if server.ErrorMessage != nil {
+				return true, server, fmt.Errorf("unrescue failed for server with id %s: %s", serverId, *server.ErrorMessage)
+			}
+			return true, server, fmt.Errorf("unrescue failed for server with id %s", serverId)
+		}
+		return false, server, nil
 	})
 	handler.SetTimeout(20 * time.Minute)
 	return handler

--- a/services/iaas/wait/wait_test.go
+++ b/services/iaas/wait/wait_test.go
@@ -832,6 +832,336 @@ func TestResizeServerWaitHandler(t *testing.T) {
 	}
 }
 
+func TestStartServerWaitHandler(t *testing.T) {
+	tests := []struct {
+		desc          string
+		getFails      bool
+		resourceState string
+		wantErr       bool
+		wantResp      bool
+	}{
+		{
+			desc:          "start_succeeded",
+			getFails:      false,
+			resourceState: ServerActiveStatus,
+			wantErr:       false,
+			wantResp:      true,
+		},
+		{
+			desc:          "error_status",
+			getFails:      false,
+			resourceState: ErrorStatus,
+			wantErr:       true,
+			wantResp:      true,
+		},
+		{
+			desc:          "get_fails",
+			getFails:      true,
+			resourceState: "",
+			wantErr:       true,
+			wantResp:      false,
+		},
+		{
+			desc:          "timeout",
+			getFails:      false,
+			resourceState: "ANOTHER Status",
+			wantErr:       true,
+			wantResp:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			apiClient := &apiClientMocked{
+				getServerFails: tt.getFails,
+				resourceState:  tt.resourceState,
+			}
+
+			var wantRes *iaas.Server
+			if tt.wantResp {
+				wantRes = &iaas.Server{
+					Id:     utils.Ptr("sid"),
+					Status: &tt.resourceState,
+				}
+			}
+
+			handler := StartServerWaitHandler(context.Background(), apiClient, "pid", "sid")
+
+			gotRes, err := handler.SetTimeout(10 * time.Millisecond).WaitWithContext(context.Background())
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("handler error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !cmp.Equal(gotRes, wantRes) {
+				t.Fatalf("handler gotRes = %v, want %v", gotRes, wantRes)
+			}
+		})
+	}
+}
+
+func TestStopServerWaitHandler(t *testing.T) {
+	tests := []struct {
+		desc          string
+		getFails      bool
+		resourceState string
+		wantErr       bool
+		wantResp      bool
+	}{
+		{
+			desc:          "stop_succeeded",
+			getFails:      false,
+			resourceState: ServerInactiveStatus,
+			wantErr:       false,
+			wantResp:      true,
+		},
+		{
+			desc:          "error_status",
+			getFails:      false,
+			resourceState: ErrorStatus,
+			wantErr:       true,
+			wantResp:      true,
+		},
+		{
+			desc:          "get_fails",
+			getFails:      true,
+			resourceState: "",
+			wantErr:       true,
+			wantResp:      false,
+		},
+		{
+			desc:          "timeout",
+			getFails:      false,
+			resourceState: "ANOTHER Status",
+			wantErr:       true,
+			wantResp:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			apiClient := &apiClientMocked{
+				getServerFails: tt.getFails,
+				resourceState:  tt.resourceState,
+			}
+
+			var wantRes *iaas.Server
+			if tt.wantResp {
+				wantRes = &iaas.Server{
+					Id:     utils.Ptr("sid"),
+					Status: &tt.resourceState,
+				}
+			}
+
+			handler := StopServerWaitHandler(context.Background(), apiClient, "pid", "sid")
+
+			gotRes, err := handler.SetTimeout(10 * time.Millisecond).WaitWithContext(context.Background())
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("handler error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !cmp.Equal(gotRes, wantRes) {
+				t.Fatalf("handler gotRes = %v, want %v", gotRes, wantRes)
+			}
+		})
+	}
+}
+
+func TestDeallocateServerWaitHandler(t *testing.T) {
+	tests := []struct {
+		desc          string
+		getFails      bool
+		resourceState string
+		wantErr       bool
+		wantResp      bool
+	}{
+		{
+			desc:          "deallocate_succeeded",
+			getFails:      false,
+			resourceState: ServerDeallocatedStatus,
+			wantErr:       false,
+			wantResp:      true,
+		},
+		{
+			desc:          "error_status",
+			getFails:      false,
+			resourceState: ErrorStatus,
+			wantErr:       true,
+			wantResp:      true,
+		},
+		{
+			desc:          "get_fails",
+			getFails:      true,
+			resourceState: "",
+			wantErr:       true,
+			wantResp:      false,
+		},
+		{
+			desc:          "timeout",
+			getFails:      false,
+			resourceState: "ANOTHER Status",
+			wantErr:       true,
+			wantResp:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			apiClient := &apiClientMocked{
+				getServerFails: tt.getFails,
+				resourceState:  tt.resourceState,
+			}
+
+			var wantRes *iaas.Server
+			if tt.wantResp {
+				wantRes = &iaas.Server{
+					Id:     utils.Ptr("sid"),
+					Status: &tt.resourceState,
+				}
+			}
+
+			handler := DeallocateServerWaitHandler(context.Background(), apiClient, "pid", "sid")
+
+			gotRes, err := handler.SetTimeout(10 * time.Millisecond).WaitWithContext(context.Background())
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("handler error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !cmp.Equal(gotRes, wantRes) {
+				t.Fatalf("handler gotRes = %v, want %v", gotRes, wantRes)
+			}
+		})
+	}
+}
+
+func TestRescueServerWaitHandler(t *testing.T) {
+	tests := []struct {
+		desc          string
+		getFails      bool
+		resourceState string
+		wantErr       bool
+		wantResp      bool
+	}{
+		{
+			desc:          "rescue_succeeded",
+			getFails:      false,
+			resourceState: ServerRescueStatus,
+			wantErr:       false,
+			wantResp:      true,
+		},
+		{
+			desc:          "error_status",
+			getFails:      false,
+			resourceState: ErrorStatus,
+			wantErr:       true,
+			wantResp:      true,
+		},
+		{
+			desc:          "get_fails",
+			getFails:      true,
+			resourceState: "",
+			wantErr:       true,
+			wantResp:      false,
+		},
+		{
+			desc:          "timeout",
+			getFails:      false,
+			resourceState: "ANOTHER Status",
+			wantErr:       true,
+			wantResp:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			apiClient := &apiClientMocked{
+				getServerFails: tt.getFails,
+				resourceState:  tt.resourceState,
+			}
+
+			var wantRes *iaas.Server
+			if tt.wantResp {
+				wantRes = &iaas.Server{
+					Id:     utils.Ptr("sid"),
+					Status: &tt.resourceState,
+				}
+			}
+
+			handler := RescueServerWaitHandler(context.Background(), apiClient, "pid", "sid")
+
+			gotRes, err := handler.SetTimeout(10 * time.Millisecond).WaitWithContext(context.Background())
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("handler error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !cmp.Equal(gotRes, wantRes) {
+				t.Fatalf("handler gotRes = %v, want %v", gotRes, wantRes)
+			}
+		})
+	}
+}
+
+func TestUnrescueServerWaitHandler(t *testing.T) {
+	tests := []struct {
+		desc          string
+		getFails      bool
+		resourceState string
+		wantErr       bool
+		wantResp      bool
+	}{
+		{
+			desc:          "unrescue_succeeded",
+			getFails:      false,
+			resourceState: ServerActiveStatus,
+			wantErr:       false,
+			wantResp:      true,
+		},
+		{
+			desc:          "error_status",
+			getFails:      false,
+			resourceState: ErrorStatus,
+			wantErr:       true,
+			wantResp:      true,
+		},
+		{
+			desc:          "get_fails",
+			getFails:      true,
+			resourceState: "",
+			wantErr:       true,
+			wantResp:      false,
+		},
+		{
+			desc:          "timeout",
+			getFails:      false,
+			resourceState: "ANOTHER Status",
+			wantErr:       true,
+			wantResp:      true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			apiClient := &apiClientMocked{
+				getServerFails: tt.getFails,
+				resourceState:  tt.resourceState,
+			}
+
+			var wantRes *iaas.Server
+			if tt.wantResp {
+				wantRes = &iaas.Server{
+					Id:     utils.Ptr("sid"),
+					Status: &tt.resourceState,
+				}
+			}
+
+			handler := UnrescueServerWaitHandler(context.Background(), apiClient, "pid", "sid")
+
+			gotRes, err := handler.SetTimeout(10 * time.Millisecond).WaitWithContext(context.Background())
+
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("handler error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !cmp.Equal(gotRes, wantRes) {
+				t.Fatalf("handler gotRes = %v, want %v", gotRes, wantRes)
+			}
+		})
+	}
+}
+
 func TestProjectRequestWaitHandler(t *testing.T) {
 	tests := []struct {
 		desc          string


### PR DESCRIPTION
- Adds waiters for server operations (start, stop, deallocate, rescue, unrescue)
- Adds all IaaS examples (copied from [`examples/iaasalpha/`](https://github.com/stackitcloud/stackit-sdk-go/tree/main/examples/iaasalpha))