### PR TITLE
feat: Update golanci-lint version and fix warnings

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go-version: ["1.18", "1.19", "1.20", "1.21", "1.22"]
+        go-version: ["1.18", "1.19", "1.20", "1.21", "1.22", "1.23"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,20 +18,19 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Install project tools and dependencies
-        if: ${{ matrix.go-version != '1.18' }}
+        if: ${{ matrix.go-version == '1.23' }}
         run: make project-tools
       - name: Lint
-        if: ${{ matrix.go-version != '1.18' }}
+        if: ${{ matrix.go-version == '1.23' }}
         run: |
           make lint
           scripts/check-sync-tidy.sh
       - name: Lint scripts
-        if: ${{ matrix.go-version == '1.22' }}
+        if: ${{ matrix.go-version == '1.23' }}
         run: |
           make lint-scripts
       - name: Test
         run: make test
       - name: Test scripts
-        if: ${{ matrix.go-version == '1.22' }}
-        run: |
-          make test-scripts
+        if: ${{ matrix.go-version >= '1.22' }}
+        run: make test-scripts

--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -56,13 +56,12 @@ func SetupAuth(cfg *config.Configuration) (rt http.RoundTripper, err error) {
 			return nil, fmt.Errorf("configuring token authentication: %w", err)
 		}
 		return tokenRoundTripper, nil
-	} else {
-		authRoundTripper, err := DefaultAuth(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("configuring default authentication: %w", err)
-		}
-		return authRoundTripper, nil
 	}
+	authRoundTripper, err := DefaultAuth(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("configuring default authentication: %w", err)
+	}
+	return authRoundTripper, nil
 }
 
 // DefaultAuth will search for a valid service account key or token in several locations.

--- a/core/clients/key_flow_continuous_refresh_test.go
+++ b/core/clients/key_flow_continuous_refresh_test.go
@@ -100,7 +100,7 @@ func TestContinuousRefreshToken(t *testing.T) {
 			}
 
 			numberDoCalls := 0
-			mockDo := func(req *http.Request) (resp *http.Response, err error) {
+			mockDo := func(_ *http.Request) (resp *http.Response, err error) {
 				numberDoCalls++
 
 				if tt.doError != nil {

--- a/core/clients/key_flow_test.go
+++ b/core/clients/key_flow_test.go
@@ -268,7 +268,7 @@ func TestRequestToken(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			mockDo := func(req *http.Request) (resp *http.Response, err error) {
+			mockDo := func(_ *http.Request) (resp *http.Response, err error) {
 				return tt.mockResponse, tt.mockError
 			}
 

--- a/core/clients/no_auth_flow_test.go
+++ b/core/clients/no_auth_flow_test.go
@@ -66,10 +66,10 @@ func TestNoAuthFlow_Do(t *testing.T) {
 			c := &NoAuthFlow{
 				client: tt.fields.client,
 			}
-			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprintln(w, `{"status":"ok"}`)
+				_, _ = fmt.Fprintln(w, `{"status":"ok"}`)
 			})
 			server := httptest.NewServer(handler)
 			defer server.Close()

--- a/core/clients/token_flow_test.go
+++ b/core/clients/token_flow_test.go
@@ -71,10 +71,10 @@ func TestTokenFlow_Do(t *testing.T) {
 				client: tt.fields.client,
 				config: tt.fields.config,
 			}
-			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Set("Content-Type", "application/json")
 				w.WriteHeader(http.StatusOK)
-				fmt.Fprintln(w, `{"status":"ok"}`)
+				_, _ = fmt.Fprintln(w, `{"status":"ok"}`)
 			})
 			server := httptest.NewServer(handler)
 			defer server.Close()

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -237,21 +237,21 @@ func WithToken(token string) ConfigurationOption {
 
 // Deprecated: retry options were removed to reduce complexity of the client. If this functionality is needed, you can provide your own custom HTTP client. This option has no effect, and will be removed in a later update
 func WithMaxRetries(_ int) ConfigurationOption {
-	return func(config *Configuration) error {
+	return func(_ *Configuration) error {
 		return nil
 	}
 }
 
 // Deprecated: retry options were removed to reduce complexity of the client. If this functionality is needed, you can provide your own custom HTTP client. This option has no effect, and will be removed in a later update
 func WithWaitBetweenCalls(_ time.Duration) ConfigurationOption {
-	return func(config *Configuration) error {
+	return func(_ *Configuration) error {
 		return nil
 	}
 }
 
 // Deprecated: retry options were removed to reduce complexity of the client. If this functionality is needed, you can provide your own custom HTTP client. This option has no effect, and will be removed in a later update
 func WithRetryTimeout(_ time.Duration) ConfigurationOption {
-	return func(config *Configuration) error {
+	return func(_ *Configuration) error {
 		return nil
 	}
 }

--- a/golang-ci.yaml
+++ b/golang-ci.yaml
@@ -14,13 +14,12 @@ linters-settings:
     # it's a comma-separated list of prefixes
     local-prefixes: github.com/freiheit-com/nmww
   depguard:
-    list-type: blacklist
-    include-go-root: false
-    packages:
-      - github.com/stretchr/testify
-    packages-with-error-message:
-      # specify an error message to output when a blacklisted package is used
-      - github.com/stretchr/testify: "do not use a testing framework"
+    rules:
+        main:
+          list-mode: lax # Everything is allowed unless it is denied
+          deny:
+            - pkg: "github.com/stretchr/testify"
+              desc: Do not use a testing framework
   misspell:
     # Correct spellings using locale preferences for US or UK.
     # Default is to use a neutral variety of English.
@@ -75,7 +74,6 @@ linters:
     - unused
     # additional linters
     - errorlint
-    - exportloopref
     - gochecknoinits
     - gocritic
     - gofmt
@@ -91,9 +89,6 @@ linters:
     - forcetypeassert
     - errcheck
   disable:
-    - structcheck # deprecated
-    - deadcode # deprecated
-    - varcheck # deprecated
     - noctx # false positive: finds errors with http.NewRequest that dont make sense
     - unparam # false positives
 issues:

--- a/scripts/project.sh
+++ b/scripts/project.sh
@@ -16,7 +16,7 @@ elif [ "$action" = "tools" ]; then
 
     go mod download
 
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.52.2
+    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
 else
     echo "Invalid action: '$action', please use $0 help for help"
 fi

--- a/services/dns/wait/wait_test.go
+++ b/services/dns/wait/wait_test.go
@@ -94,7 +94,7 @@ func TestCreateZoneWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &dns.ZoneResponse{
 					Zone: &dns.Zone{
-						State: &tt.resourceState,
+						State: utils.Ptr(tt.resourceState),
 						Id:    utils.Ptr("zid"),
 					},
 				}
@@ -162,7 +162,7 @@ func TestUpdateZoneWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &dns.ZoneResponse{
 					Zone: &dns.Zone{
-						State: &tt.resourceState,
+						State: utils.Ptr(tt.resourceState),
 						Id:    utils.Ptr("zid"),
 					},
 				}
@@ -230,7 +230,7 @@ func TestDeleteZoneWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &dns.ZoneResponse{
 					Zone: &dns.Zone{
-						State: &tt.resourceState,
+						State: utils.Ptr(tt.resourceState),
 						Id:    utils.Ptr("zid"),
 					},
 				}
@@ -300,7 +300,7 @@ func TestCreateRecordSetWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &dns.RecordSetResponse{
 					Rrset: &dns.RecordSet{
-						State: &tt.resourceState,
+						State: utils.Ptr(tt.resourceState),
 						Id:    utils.Ptr("rid"),
 					},
 				}
@@ -368,7 +368,7 @@ func TestUpdateRecordSetWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &dns.RecordSetResponse{
 					Rrset: &dns.RecordSet{
-						State: &tt.resourceState,
+						State: utils.Ptr(tt.resourceState),
 						Id:    utils.Ptr("rid"),
 					},
 				}
@@ -436,7 +436,7 @@ func TestDeleteRecordSetWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &dns.RecordSetResponse{
 					Rrset: &dns.RecordSet{
-						State: &tt.resourceState,
+						State: utils.Ptr(tt.resourceState),
 						Id:    utils.Ptr("rid"),
 					},
 				}

--- a/services/iaas/wait/wait_test.go
+++ b/services/iaas/wait/wait_test.go
@@ -183,7 +183,7 @@ func TestCreateNetworkAreaWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.NetworkArea{
 					AreaId: utils.Ptr("naid"),
-					State:  &tt.resourceState,
+					State:  utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -242,7 +242,7 @@ func TestUpdateNetworkAreaWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.NetworkArea{
 					AreaId: utils.Ptr("naid"),
-					State:  &tt.resourceState,
+					State:  utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -303,7 +303,7 @@ func TestDeleteNetworkAreaWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.NetworkArea{
 					AreaId: utils.Ptr("naid"),
-					State:  &tt.resourceState,
+					State:  utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -362,7 +362,7 @@ func TestCreateNetworkWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Network{
 					NetworkId: utils.Ptr("nid"),
-					State:     &tt.resourceState,
+					State:     utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -421,7 +421,7 @@ func TestUpdateNetworkWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Network{
 					NetworkId: utils.Ptr("nid"),
-					State:     &tt.resourceState,
+					State:     utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -482,7 +482,7 @@ func TestDeleteNetworkWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Network{
 					NetworkId: utils.Ptr("nid"),
-					State:     &tt.resourceState,
+					State:     utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -548,7 +548,7 @@ func TestCreateVolumeWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Volume{
 					Id:     utils.Ptr("vid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -609,7 +609,7 @@ func TestDeleteVolumeWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Volume{
 					Id:     utils.Ptr("vid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -675,7 +675,7 @@ func TestCreateServerWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Server{
 					Id:     utils.Ptr("sid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -736,7 +736,7 @@ func TestDeleteServerWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Server{
 					Id:     utils.Ptr("sid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -814,7 +814,7 @@ func TestResizeServerWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Server{
 					Id:     utils.Ptr("sid"),
-					Status: &tt.finalResourceState,
+					Status: utils.Ptr(tt.finalResourceState),
 				}
 			}
 
@@ -880,7 +880,7 @@ func TestStartServerWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Server{
 					Id:     utils.Ptr("sid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -946,7 +946,7 @@ func TestStopServerWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Server{
 					Id:     utils.Ptr("sid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -1012,7 +1012,7 @@ func TestDeallocateServerWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Server{
 					Id:     utils.Ptr("sid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -1078,7 +1078,7 @@ func TestRescueServerWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Server{
 					Id:     utils.Ptr("sid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -1144,7 +1144,7 @@ func TestUnrescueServerWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Server{
 					Id:     utils.Ptr("sid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -1238,8 +1238,8 @@ func TestProjectRequestWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaas.Request{
 					RequestId:     utils.Ptr("rid"),
-					RequestAction: &tt.requestAction,
-					Status:        &tt.requestState,
+					RequestAction: utils.Ptr(tt.requestAction),
+					Status:        utils.Ptr(tt.requestState),
 				}
 			}
 

--- a/services/iaasalpha/wait/wait_test.go
+++ b/services/iaasalpha/wait/wait_test.go
@@ -150,7 +150,7 @@ func TestCreateVolumeWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaasalpha.Volume{
 					Id:     utils.Ptr("vid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -211,7 +211,7 @@ func TestDeleteVolumeWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaasalpha.Volume{
 					Id:     utils.Ptr("vid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -277,7 +277,7 @@ func TestCreateServerWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaasalpha.Server{
 					Id:     utils.Ptr("sid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -338,7 +338,7 @@ func TestDeleteServerWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaasalpha.Server{
 					Id:     utils.Ptr("sid"),
-					Status: &tt.resourceState,
+					Status: utils.Ptr(tt.resourceState),
 				}
 			}
 
@@ -416,7 +416,7 @@ func TestResizeServerWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaasalpha.Server{
 					Id:     utils.Ptr("sid"),
-					Status: &tt.finalResourceState,
+					Status: utils.Ptr(tt.finalResourceState),
 				}
 			}
 
@@ -510,8 +510,8 @@ func TestProjectRequestWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &iaasalpha.Request{
 					RequestId:     utils.Ptr("rid"),
-					RequestAction: &tt.requestAction,
-					Status:        &tt.requestState,
+					RequestAction: utils.Ptr(tt.requestAction),
+					Status:        utils.Ptr(tt.requestState),
 				}
 			}
 

--- a/services/loadbalancer/wait/wait_test.go
+++ b/services/loadbalancer/wait/wait_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
+	"github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/loadbalancer"
 )
 
@@ -107,7 +108,7 @@ func TestCreateInstanceWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &loadbalancer.LoadBalancer{
 					Name:   &instanceName,
-					Status: &tt.instanceStatus,
+					Status: utils.Ptr(tt.instanceStatus),
 				}
 			}
 
@@ -218,7 +219,7 @@ func TestEnableServiceWaitHandler(t *testing.T) {
 			var wantRes *loadbalancer.GetServiceStatusResponse
 			if tt.wantResp {
 				wantRes = &loadbalancer.GetServiceStatusResponse{
-					Status: &tt.functionalityStatus,
+					Status: utils.Ptr(tt.functionalityStatus),
 				}
 			}
 

--- a/services/logme/wait/wait_test.go
+++ b/services/logme/wait/wait_test.go
@@ -138,7 +138,7 @@ func TestCreateInstanceWaitHandler(t *testing.T) {
 					InstanceId: &instanceId,
 					LastOperation: &logme.InstanceLastOperation{
 						Type:        &instanceTypeCreate,
-						State:       &tt.resourceState,
+						State:       utils.Ptr(tt.resourceState),
 						Description: utils.Ptr(""),
 					},
 				}
@@ -212,7 +212,7 @@ func TestUpdateInstanceWaitHandler(t *testing.T) {
 					InstanceId: &instanceId,
 					LastOperation: &logme.InstanceLastOperation{
 						Type:        &instanceTypeUpdate,
-						State:       &tt.resourceState,
+						State:       utils.Ptr(tt.resourceState),
 						Description: utils.Ptr(""),
 					},
 				}

--- a/services/mariadb/wait/wait_test.go
+++ b/services/mariadb/wait/wait_test.go
@@ -138,7 +138,7 @@ func TestCreateInstanceWaitHandler(t *testing.T) {
 					InstanceId: &instanceId,
 					LastOperation: &mariadb.InstanceLastOperation{
 						Type:        &instanceTypeCreate,
-						State:       &tt.resourceState,
+						State:       utils.Ptr(tt.resourceState),
 						Description: utils.Ptr(""),
 					},
 				}
@@ -212,7 +212,7 @@ func TestUpdateInstanceWaitHandler(t *testing.T) {
 					InstanceId: &instanceId,
 					LastOperation: &mariadb.InstanceLastOperation{
 						Type:        &instanceTypeUpdate,
-						State:       &tt.resourceState,
+						State:       utils.Ptr(tt.resourceState),
 						Description: utils.Ptr(""),
 					},
 				}

--- a/services/mongodbflex/wait/wait_test.go
+++ b/services/mongodbflex/wait/wait_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
+	"github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/mongodbflex"
 )
 
@@ -119,7 +120,7 @@ func TestCreateInstanceWaitHandler(t *testing.T) {
 				wantRes = &mongodbflex.GetInstanceResponse{
 					Item: &mongodbflex.Instance{
 						Id:     &instanceId,
-						Status: &tt.instanceState,
+						Status: utils.Ptr(tt.instanceState),
 					},
 				}
 			}
@@ -196,7 +197,7 @@ func TestUpdateInstanceWaitHandler(t *testing.T) {
 				wantRes = &mongodbflex.GetInstanceResponse{
 					Item: &mongodbflex.Instance{
 						Id:     &instanceId,
-						Status: &tt.instanceState,
+						Status: utils.Ptr(tt.instanceState),
 					},
 				}
 			}
@@ -320,7 +321,7 @@ func TestRestoreInstanceWaitHandler(t *testing.T) {
 				wantRes = &mongodbflex.ListRestoreJobsResponse{
 					Items: &[]mongodbflex.RestoreInstanceStatus{
 						{
-							Status:   &tt.restoreState,
+							Status:   utils.Ptr(tt.restoreState),
 							BackupID: &backupId,
 						},
 					},

--- a/services/observability/wait/wait_test.go
+++ b/services/observability/wait/wait_test.go
@@ -288,7 +288,7 @@ func TestCreateScrapeConfigWaitHandler(t *testing.T) {
 			var wantRes *observability.ListScrapeConfigsResponse
 			if tt.wantResp {
 				wantRes = &observability.ListScrapeConfigsResponse{
-					Data: &tt.jobs,
+					Data: utils.Ptr(tt.jobs),
 				}
 			}
 
@@ -346,7 +346,7 @@ func TestDeleteScrapeConfigWaitHandler(t *testing.T) {
 			var wantRes *observability.ListScrapeConfigsResponse
 			if tt.wantResp {
 				wantRes = &observability.ListScrapeConfigsResponse{
-					Data: &tt.jobs,
+					Data: utils.Ptr(tt.jobs),
 				}
 			}
 

--- a/services/opensearch/wait/wait_test.go
+++ b/services/opensearch/wait/wait_test.go
@@ -138,7 +138,7 @@ func TestCreateInstanceWaitHandler(t *testing.T) {
 					InstanceId: &instanceId,
 					LastOperation: &opensearch.InstanceLastOperation{
 						Type:        &instanceTypeCreate,
-						State:       &tt.resourceState,
+						State:       utils.Ptr(tt.resourceState),
 						Description: utils.Ptr(""),
 					},
 				}
@@ -212,7 +212,7 @@ func TestUpdateInstanceWaitHandler(t *testing.T) {
 					InstanceId: &instanceId,
 					LastOperation: &opensearch.InstanceLastOperation{
 						Type:        &instanceTypeUpdate,
-						State:       &tt.resourceState,
+						State:       utils.Ptr(tt.resourceState),
 						Description: utils.Ptr(""),
 					},
 				}

--- a/services/postgresflex/wait/wait_test.go
+++ b/services/postgresflex/wait/wait_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
+	"github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/postgresflex"
 )
 
@@ -157,7 +158,7 @@ func TestCreateInstanceWaitHandler(t *testing.T) {
 				wantRes = &postgresflex.InstanceResponse{
 					Item: &postgresflex.Instance{
 						Id:     &instanceId,
-						Status: &tt.instanceState,
+						Status: utils.Ptr(tt.instanceState),
 					},
 				}
 			}
@@ -234,7 +235,7 @@ func TestUpdateInstanceWaitHandler(t *testing.T) {
 				wantRes = &postgresflex.InstanceResponse{
 					Item: &postgresflex.Instance{
 						Id:     &instanceId,
-						Status: &tt.instanceState,
+						Status: utils.Ptr(tt.instanceState),
 					},
 				}
 			}

--- a/services/rabbitmq/wait/wait_test.go
+++ b/services/rabbitmq/wait/wait_test.go
@@ -138,7 +138,7 @@ func TestCreateInstanceWaitHandler(t *testing.T) {
 					InstanceId: &instanceId,
 					LastOperation: &rabbitmq.InstanceLastOperation{
 						Type:        &instanceTypeCreate,
-						State:       &tt.resourceState,
+						State:       utils.Ptr(tt.resourceState),
 						Description: utils.Ptr(""),
 					},
 				}
@@ -212,7 +212,7 @@ func TestUpdateInstanceWaitHandler(t *testing.T) {
 					InstanceId: &instanceId,
 					LastOperation: &rabbitmq.InstanceLastOperation{
 						Type:        &instanceTypeUpdate,
-						State:       &tt.resourceState,
+						State:       utils.Ptr(tt.resourceState),
 						Description: utils.Ptr(""),
 					},
 				}

--- a/services/redis/wait/wait_test.go
+++ b/services/redis/wait/wait_test.go
@@ -138,7 +138,7 @@ func TestCreateInstanceWaitHandler(t *testing.T) {
 					InstanceId: &instanceId,
 					LastOperation: &redis.InstanceLastOperation{
 						Type:        &instanceTypeCreate,
-						State:       &tt.resourceState,
+						State:       utils.Ptr(tt.resourceState),
 						Description: utils.Ptr(""),
 					},
 				}
@@ -212,7 +212,7 @@ func TestUpdateInstanceWaitHandler(t *testing.T) {
 					InstanceId: &instanceId,
 					LastOperation: &redis.InstanceLastOperation{
 						Type:        &instanceTypeUpdate,
-						State:       &tt.resourceState,
+						State:       utils.Ptr(tt.resourceState),
 						Description: utils.Ptr(""),
 					},
 				}

--- a/services/resourcemanager/wait/wait_test.go
+++ b/services/resourcemanager/wait/wait_test.go
@@ -84,7 +84,7 @@ func TestCreateProjectWaitHandler(t *testing.T) {
 			var wantRes *resourcemanager.GetProjectResponse
 			if tt.wantResp {
 				wantRes = &resourcemanager.GetProjectResponse{
-					LifecycleState: &tt.projectState,
+					LifecycleState: utils.Ptr(tt.projectState),
 					ContainerId:    utils.Ptr("cid"),
 				}
 			}

--- a/services/serviceenablement/wait/wait_test.go
+++ b/services/serviceenablement/wait/wait_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
+	"github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/serviceenablement"
 )
 
@@ -88,7 +89,7 @@ func TestEnableServiceWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &serviceenablement.ServiceStatus{
 					ServiceId: &serviceId,
-					State:     &tt.serviceState,
+					State:     utils.Ptr(tt.serviceState),
 				}
 			}
 
@@ -170,7 +171,7 @@ func TestDisableServiceWaitHandler(t *testing.T) {
 			if tt.wantResp {
 				wantRes = &serviceenablement.ServiceStatus{
 					ServiceId: &serviceId,
-					State:     &tt.serviceState,
+					State:     utils.Ptr(tt.serviceState),
 				}
 			}
 

--- a/services/sqlserverflex/wait/wait_test.go
+++ b/services/sqlserverflex/wait/wait_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stackitcloud/stackit-sdk-go/core/oapierror"
+	"github.com/stackitcloud/stackit-sdk-go/core/utils"
 	"github.com/stackitcloud/stackit-sdk-go/services/sqlserverflex"
 )
 
@@ -97,7 +98,7 @@ func TestCreateInstanceWaitHandler(t *testing.T) {
 				wantRes = &sqlserverflex.GetInstanceResponse{
 					Item: &sqlserverflex.Instance{
 						Id:     &instanceId,
-						Status: &tt.instanceState,
+						Status: utils.Ptr(tt.instanceState),
 					},
 				}
 			}
@@ -174,7 +175,7 @@ func TestUpdateInstanceWaitHandler(t *testing.T) {
 				wantRes = &sqlserverflex.GetInstanceResponse{
 					Item: &sqlserverflex.Instance{
 						Id:     &instanceId,
-						Status: &tt.instanceState,
+						Status: utils.Ptr(tt.instanceState),
 					},
 				}
 			}


### PR DESCRIPTION
- Remove reference to deprecated and removed linters: `exportloopref`, `structcheck`, `deadcode`, `varcheck`
- Fix some warnings 
- Only lint with one of the Go versions in CI, still test with all supported