### PR TITLE
Allow lint and test specific service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ project-tools:
 # LINT
 lint-golangci-lint:
 	@echo "Linting with golangci-lint"
-	@$(SCRIPTS_BASE)/lint-golangci-lint.sh ${skip-non-generated-files}
+	@$(SCRIPTS_BASE)/lint-golangci-lint.sh "${skip-non-generated-files}" "${service}"
 
 lint-scripts:
 	@echo "Linting scripts"
@@ -24,19 +24,19 @@ sync-tidy:
 	@$(SCRIPTS_BASE)/sync-tidy.sh
 
 lint: sync-tidy
-	@$(MAKE) --no-print-directory lint-golangci-lint skip-non-generated-files=${skip-non-generated-files}
+	@$(MAKE) --no-print-directory lint-golangci-lint skip-non-generated-files=${skip-non-generated-files} service=${service}
 
 # TEST
 test-go:
 	@echo "Running Go tests"
-	@$(SCRIPTS_BASE)/test-go.sh ${skip-non-generated-files}
+	@$(SCRIPTS_BASE)/test-go.sh "${skip-non-generated-files}" "${service}"
 
 test-scripts:
 	@echo "Running Go tests for scripts"
 	@go test $(ROOT_DIR)/scripts/... ${GOTEST_ARGS}
 
 test:
-	@$(MAKE) --no-print-directory test-go skip-non-generated-files=${skip-non-generated-files}
+	@$(MAKE) --no-print-directory test-go skip-non-generated-files=${skip-non-generated-files} service=${service}
 
 # AUTOMATIC TAG
 sdk-tag-services:

--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,15 @@ project-tools:
 
 # LINT
 lint-golangci-lint:
-	@echo "Linting with golangci-lint"
+	@echo ">> Linting with golangci-lint"
 	@$(SCRIPTS_BASE)/lint-golangci-lint.sh "${skip-non-generated-files}" "${service}"
 
 lint-scripts:
-	@echo "Linting scripts"
+	@echo ">> Linting scripts"
 	@cd ${ROOT_DIR}/scripts && golangci-lint run ${GOLANG_CI_ARGS}
 
 sync-tidy:
-	@echo "Syncing and tidying dependencies"
+	@echo ">> Syncing and tidying dependencies"
 	@$(SCRIPTS_BASE)/sync-tidy.sh
 
 lint: sync-tidy
@@ -28,11 +28,11 @@ lint: sync-tidy
 
 # TEST
 test-go:
-	@echo "Running Go tests"
+	@echo ">> Running Go tests"
 	@$(SCRIPTS_BASE)/test-go.sh "${skip-non-generated-files}" "${service}"
 
 test-scripts:
-	@echo "Running Go tests for scripts"
+	@echo ">> Running Go tests for scripts"
 	@go test $(ROOT_DIR)/scripts/... ${GOTEST_ARGS}
 
 test:

--- a/scripts/lint-golangci-lint.sh
+++ b/scripts/lint-golangci-lint.sh
@@ -4,17 +4,22 @@
 # Pre-requisites: golangci-lint
 set -eo pipefail
 
-SKIP_NON_GENERATED_FILES="${1}"
-if [ ! "${SKIP_NON_GENERATED_FILES}" = true ]; then
-    SKIP_NON_GENERATED_FILES=false
-fi
-
+# Global flags
 ROOT_DIR=$(git rev-parse --show-toplevel)
 CORE_PATH="${ROOT_DIR}/core"
 SERVICES_PATH="${ROOT_DIR}/services"
 EXAMPLES_PATH="${ROOT_DIR}/examples"
 GOLANG_CI_YAML_PATH="${ROOT_DIR}/golang-ci.yaml"
 GOLANG_CI_ARGS="--allow-parallel-runners --timeout=5m --config=${GOLANG_CI_YAML_PATH}"
+
+# Arguments
+SKIP_NON_GENERATED_FILES="${1}"
+SERVICE="${2}"
+
+# Default values
+if [ ! "${SKIP_NON_GENERATED_FILES}" = true ]; then
+    SKIP_NON_GENERATED_FILES=false
+fi
 
 if type -p golangci-lint >/dev/null; then
     :
@@ -23,28 +28,40 @@ else
     exit 1
 fi
 
-if [ "${SKIP_NON_GENERATED_FILES}" = false ]; then
-    echo ">> Linting core"
-    cd ${CORE_PATH}
-    golangci-lint run ${GOLANG_CI_ARGS}
-fi
-
-for service_dir in ${SERVICES_PATH}/*; do
-    service=$(basename ${service_dir})
-    echo ">> Linting service ${service}"
-    cd ${service_dir}
+# If a service is specified, only lint that service
+if [ ! -z "${SERVICE}" ]; then
+    echo ">> Linting service ${SERVICE}"
+    cd ${SERVICES_PATH}/${SERVICE}
     if [ "${SKIP_NON_GENERATED_FILES}" = true ]; then
         golangci-lint run ${GOLANG_CI_ARGS} --skip-dirs wait # All manually maintained files are in subfolders
     else
         golangci-lint run ${GOLANG_CI_ARGS}
     fi
-done
-
-if [ "${SKIP_NON_GENERATED_FILES}" = false ]; then
-    for example_dir in ${EXAMPLES_PATH}/*; do
-        example=$(basename ${example_dir})
-        echo ">> Linting example ${example}"
-        cd ${example_dir}
+# Otherwise, lint all modules and examples
+else
+    if [ "${SKIP_NON_GENERATED_FILES}" = false ]; then
+        echo ">> Linting core"
+        cd ${CORE_PATH}
         golangci-lint run ${GOLANG_CI_ARGS}
+    fi
+
+    for service_dir in ${SERVICES_PATH}/*; do
+        service=$(basename ${service_dir})
+        echo ">> Linting service ${service}"
+        cd ${service_dir}
+        if [ "${SKIP_NON_GENERATED_FILES}" = true ]; then
+            golangci-lint run ${GOLANG_CI_ARGS} --skip-dirs wait # All manually maintained files are in subfolders
+        else
+            golangci-lint run ${GOLANG_CI_ARGS}
+        fi
     done
+
+    if [ "${SKIP_NON_GENERATED_FILES}" = false ]; then
+        for example_dir in ${EXAMPLES_PATH}/*; do
+            example=$(basename ${example_dir})
+            echo ">> Linting example ${example}"
+            cd ${example_dir}
+            golangci-lint run ${GOLANG_CI_ARGS}
+        done
+    fi
 fi

--- a/scripts/lint-golangci-lint.sh
+++ b/scripts/lint-golangci-lint.sh
@@ -28,15 +28,21 @@ else
     exit 1
 fi
 
-# If a service is specified, only lint that service
-if [ ! -z "${SERVICE}" ]; then
-    echo ">> Linting service ${SERVICE}"
-    cd ${SERVICES_PATH}/${SERVICE}
+lint_service() {
+    service=$1
+
+    echo ">> Linting service ${service}"
+    cd ${SERVICES_PATH}/${service}
     if [ "${SKIP_NON_GENERATED_FILES}" = true ]; then
         golangci-lint run ${GOLANG_CI_ARGS} --skip-dirs wait # All manually maintained files are in subfolders
     else
         golangci-lint run ${GOLANG_CI_ARGS}
     fi
+}
+
+# If a service is specified, only lint that service
+if [ ! -z "${SERVICE}" ]; then
+    lint_service ${SERVICE}
 # Otherwise, lint all modules and examples
 else
     if [ "${SKIP_NON_GENERATED_FILES}" = false ]; then
@@ -47,13 +53,7 @@ else
 
     for service_dir in ${SERVICES_PATH}/*; do
         service=$(basename ${service_dir})
-        echo ">> Linting service ${service}"
-        cd ${service_dir}
-        if [ "${SKIP_NON_GENERATED_FILES}" = true ]; then
-            golangci-lint run ${GOLANG_CI_ARGS} --skip-dirs wait # All manually maintained files are in subfolders
-        else
-            golangci-lint run ${GOLANG_CI_ARGS}
-        fi
+        lint_service ${service}
     done
 
     if [ "${SKIP_NON_GENERATED_FILES}" = false ]; then

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -25,23 +25,25 @@ else
     exit 1
 fi
 
+test_service() {
+    service=$1
+
+    echo ">> Testing services/${service}"
+    if [ "${SKIP_NON_GENERATED_FILES}" = true ]; then
+        go test ${SERVICES_PATH}/${service}/... ${GOTEST_ARGS} # All manually maintained files are in subfolders
+    else
+        go test ${SERVICES_PATH}/${service}/... ${GOTEST_ARGS}
+    fi
+}
+
 # If a service is specified, only test that service
 if [ ! -z "${SERVICE}" ]; then
-    echo ">> Testing services/${SERVICE}"
-    cd ${SERVICES_PATH}/${SERVICE}
-    if [ "${SKIP_NON_GENERATED_FILES}" = true ]; then
-        go test ./ ${GOTEST_ARGS} # All manually maintained files are in subfolders
-    else
-        go test ./... ${GOTEST_ARGS}
-    fi
-    exit 0
-# Otherwise, test all modules
+    test_service ${SERVICE}
+# Otherwise, test all services and core
 else
-
     if [ "${SKIP_NON_GENERATED_FILES}" = false ]; then
         echo ">> Testing core"
-        cd ${CORE_PATH}
-        go test ./... ${GOTEST_ARGS}
+        go test ${CORE_PATH}/... ${GOTEST_ARGS}
     fi
 
     for service_dir in ${SERVICES_PATH}/*; do
@@ -54,12 +56,6 @@ else
             continue
         fi
 
-        echo ">> Testing services/${service}"
-        cd ${service_dir}
-        if [ "${SKIP_NON_GENERATED_FILES}" = true ]; then
-            go test ./ ${GOTEST_ARGS} # All manually maintained files are in subfolders
-        else
-            go test ./... ${GOTEST_ARGS}
-        fi
+        test_service ${service}
     done
 fi

--- a/scripts/test-go.sh
+++ b/scripts/test-go.sh
@@ -4,7 +4,11 @@
 # Pre-requisites: Go
 set -eo pipefail
 
+# Arguments
 SKIP_NON_GENERATED_FILES="${1}"
+SERVICE="${2}"
+
+# Default values
 if [ ! "${SKIP_NON_GENERATED_FILES}" = true ]; then
     SKIP_NON_GENERATED_FILES=false
 fi
@@ -21,27 +25,41 @@ else
     exit 1
 fi
 
-if [ "${SKIP_NON_GENERATED_FILES}" = false ]; then
-    echo ">> Testing core"
-    cd ${CORE_PATH}
-    go test ./... ${GOTEST_ARGS}
-fi
-
-for service_dir in ${SERVICES_PATH}/*; do
-    service=$(basename ${service_dir})
-
-    # Our unit test template fails because it doesn't support fields with validations,
-    # such as the UUID component used by IaaS. We introduce this hardcoded skip until we fix it
-    if [ "${service}" = "iaas" ] || [ "${service}" = "iaasalpha" ]; then
-        echo ">> Skipping services/${service}"
-        continue
-    fi
-
-    echo ">> Testing services/${service}"
-    cd ${service_dir}
+# If a service is specified, only test that service
+if [ ! -z "${SERVICE}" ]; then
+    echo ">> Testing services/${SERVICE}"
+    cd ${SERVICES_PATH}/${SERVICE}
     if [ "${SKIP_NON_GENERATED_FILES}" = true ]; then
         go test ./ ${GOTEST_ARGS} # All manually maintained files are in subfolders
     else
         go test ./... ${GOTEST_ARGS}
     fi
-done
+    exit 0
+# Otherwise, test all modules
+else
+
+    if [ "${SKIP_NON_GENERATED_FILES}" = false ]; then
+        echo ">> Testing core"
+        cd ${CORE_PATH}
+        go test ./... ${GOTEST_ARGS}
+    fi
+
+    for service_dir in ${SERVICES_PATH}/*; do
+        service=$(basename ${service_dir})
+
+        # Our unit test template fails because it doesn't support fields with validations,
+        # such as the UUID component used by IaaS. We introduce this hardcoded skip until we fix it
+        if [ "${service}" = "iaas" ] || [ "${service}" = "iaasalpha" ]; then
+            echo ">> Skipping services/${service}"
+            continue
+        fi
+
+        echo ">> Testing services/${service}"
+        cd ${service_dir}
+        if [ "${SKIP_NON_GENERATED_FILES}" = true ]; then
+            go test ./ ${GOTEST_ARGS} # All manually maintained files are in subfolders
+        else
+            go test ./... ${GOTEST_ARGS}
+        fi
+    done
+fi


### PR DESCRIPTION
- Allow `lint` and `test` a specific service via:
  - `$ make lint service=SERVICE_NAME`
  - `$ make test service=SERVICE_NAME`
- Default `make lint` and `make test` keeps previous behaviour of running for all services and `core`