### PR TITLE
Deprecate service_account_email config option

### DIFF
--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -14,7 +14,7 @@ import (
 type credentialType string
 
 type Credentials struct {
-	STACKIT_SERVICE_ACCOUNT_EMAIL    string
+	STACKIT_SERVICE_ACCOUNT_EMAIL    string // Deprecated: ServiceAccountEmail is not required anymore.
 	STACKIT_SERVICE_ACCOUNT_TOKEN    string
 	STACKIT_SERVICE_ACCOUNT_KEY_PATH string
 	STACKIT_PRIVATE_KEY_PATH         string
@@ -32,8 +32,6 @@ const (
 func SetupAuth(cfg *config.Configuration) (rt http.RoundTripper, err error) {
 	if cfg == nil {
 		cfg = &config.Configuration{}
-		email := getServiceAccountEmail(cfg)
-		cfg.ServiceAccountEmail = email
 	}
 
 	if cfg.CustomAuth != nil {
@@ -242,25 +240,6 @@ func readCredential(cred credentialType, credentials *Credentials) (string, erro
 	}
 
 	return credentialValue, nil
-}
-
-// getServiceAccountEmail searches for an email in the following order: client configuration, environment variable, credentials file.
-// is not required for authentication, so it can be empty.
-func getServiceAccountEmail(cfg *config.Configuration) string {
-	if cfg.ServiceAccountEmail != "" {
-		return cfg.ServiceAccountEmail
-	}
-
-	email, emailSet := os.LookupEnv("STACKIT_SERVICE_ACCOUNT_EMAIL")
-	if !emailSet || email == "" {
-		credentials, err := readCredentialsFile(cfg.CredentialsFilePath)
-		if err != nil {
-			// email is not required for authentication, so it shouldnt block it
-			return ""
-		}
-		return credentials.STACKIT_SERVICE_ACCOUNT_EMAIL
-	}
-	return email
 }
 
 // getKey searches for a key in the following order: client configuration, environment variable, credentials file.

--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -14,7 +14,7 @@ import (
 type credentialType string
 
 type Credentials struct {
-	STACKIT_SERVICE_ACCOUNT_EMAIL    string // Deprecated: ServiceAccountEmail is not required anymore.
+	STACKIT_SERVICE_ACCOUNT_EMAIL    string // Deprecated: ServiceAccountEmail is not required and will be removed after 12th June 2025.
 	STACKIT_SERVICE_ACCOUNT_TOKEN    string
 	STACKIT_SERVICE_ACCOUNT_KEY_PATH string
 	STACKIT_PRIVATE_KEY_PATH         string

--- a/core/auth/auth_test.go
+++ b/core/auth/auth_test.go
@@ -170,8 +170,6 @@ func TestSetupAuth(t *testing.T) {
 				t.Setenv("STACKIT_CREDENTIALS_PATH", "")
 			}
 
-			t.Setenv("STACKIT_SERVICE_ACCOUNT_EMAIL", "test-email")
-
 			authRoundTripper, err := SetupAuth(test.config)
 
 			if err != nil && test.isValid {
@@ -565,78 +563,6 @@ func TestNoAuth(t *testing.T) {
 
 			if authClient == nil {
 				t.Fatalf("Client returned is nil for valid test case")
-			}
-		})
-	}
-}
-
-func TestGetServiceAccountEmail(t *testing.T) {
-	for _, test := range []struct {
-		description   string
-		cfg           *config.Configuration
-		envEmailSet   bool
-		path          string
-		expectedEmail string
-		isValid       bool
-	}{
-		{
-			description: "custom_config",
-			cfg: &config.Configuration{
-				ServiceAccountEmail: "test_email",
-			},
-			path:          "",
-			expectedEmail: "test_email",
-			isValid:       true,
-		},
-		{
-			description:   "config_over_env_var",
-			cfg:           &config.Configuration{},
-			envEmailSet:   true,
-			path:          "",
-			expectedEmail: "env_email",
-			isValid:       true,
-		},
-		{
-			description: "env_variable",
-			cfg: &config.Configuration{
-				ServiceAccountEmail: "test_email",
-			},
-			envEmailSet:   true,
-			path:          "",
-			expectedEmail: "test_email",
-			isValid:       true,
-		},
-		{
-			description:   "path",
-			cfg:           &config.Configuration{},
-			envEmailSet:   false,
-			path:          "test_resources/test_credentials_bar.json",
-			expectedEmail: "bar_email",
-			isValid:       true,
-		},
-		{
-			description:   "invalid_structure",
-			cfg:           &config.Configuration{},
-			envEmailSet:   false,
-			path:          "test_resources/test_invalid_structure.json",
-			expectedEmail: "",
-			isValid:       false,
-		},
-	} {
-		t.Run(test.description, func(t *testing.T) {
-			if test.envEmailSet {
-				t.Setenv("STACKIT_SERVICE_ACCOUNT_EMAIL", "env_email")
-			} else {
-				t.Setenv("STACKIT_SERVICE_ACCOUNT_EMAIL", "")
-			}
-			t.Setenv("STACKIT_CREDENTIALS_PATH", test.path)
-			got := getServiceAccountEmail(test.cfg)
-			if (got != "") && !test.isValid {
-				t.Errorf("getServiceAccountEmail() did not return empty value for invalid test case")
-				return
-			}
-			if got != test.expectedEmail {
-				t.Errorf("getServiceAccountEmail() = %v, want %v", got, test.expectedEmail)
 			}
 		})
 	}

--- a/core/auth/auth_test.go
+++ b/core/auth/auth_test.go
@@ -170,6 +170,8 @@ func TestSetupAuth(t *testing.T) {
 				t.Setenv("STACKIT_CREDENTIALS_PATH", "")
 			}
 
+			t.Setenv("STACKIT_SERVICE_ACCOUNT_EMAIL", "test-email")
+
 			authRoundTripper, err := SetupAuth(test.config)
 
 			if err != nil && test.isValid {
@@ -563,6 +565,78 @@ func TestNoAuth(t *testing.T) {
 
 			if authClient == nil {
 				t.Fatalf("Client returned is nil for valid test case")
+			}
+		})
+	}
+}
+
+func TestGetServiceAccountEmail(t *testing.T) {
+	for _, test := range []struct {
+		description   string
+		cfg           *config.Configuration
+		envEmailSet   bool
+		path          string
+		expectedEmail string
+		isValid       bool
+	}{
+		{
+			description: "custom_config",
+			cfg: &config.Configuration{
+				ServiceAccountEmail: "test_email",
+			},
+			path:          "",
+			expectedEmail: "test_email",
+			isValid:       true,
+		},
+		{
+			description:   "config_over_env_var",
+			cfg:           &config.Configuration{},
+			envEmailSet:   true,
+			path:          "",
+			expectedEmail: "env_email",
+			isValid:       true,
+		},
+		{
+			description: "env_variable",
+			cfg: &config.Configuration{
+				ServiceAccountEmail: "test_email",
+			},
+			envEmailSet:   true,
+			path:          "",
+			expectedEmail: "test_email",
+			isValid:       true,
+		},
+		{
+			description:   "path",
+			cfg:           &config.Configuration{},
+			envEmailSet:   false,
+			path:          "test_resources/test_credentials_bar.json",
+			expectedEmail: "bar_email",
+			isValid:       true,
+		},
+		{
+			description:   "invalid_structure",
+			cfg:           &config.Configuration{},
+			envEmailSet:   false,
+			path:          "test_resources/test_invalid_structure.json",
+			expectedEmail: "",
+			isValid:       false,
+		},
+	} {
+		t.Run(test.description, func(t *testing.T) {
+			if test.envEmailSet {
+				t.Setenv("STACKIT_SERVICE_ACCOUNT_EMAIL", "env_email")
+			} else {
+				t.Setenv("STACKIT_SERVICE_ACCOUNT_EMAIL", "")
+			}
+			t.Setenv("STACKIT_CREDENTIALS_PATH", test.path)
+			got := getServiceAccountEmail(test.cfg)
+			if (got != "") && !test.isValid {
+				t.Errorf("getServiceAccountEmail() did not return empty value for invalid test case")
+				return
+			}
+			if got != test.expectedEmail {
+				t.Errorf("getServiceAccountEmail() = %v, want %v", got, test.expectedEmail)
 			}
 		})
 	}

--- a/core/clients/token_flow.go
+++ b/core/clients/token_flow.go
@@ -19,7 +19,7 @@ type TokenFlow struct {
 
 // TokenFlowConfig is the flow config
 type TokenFlowConfig struct {
-	// Deprecated: ServiceAccountEmail is not required anymore.
+	// Deprecated: ServiceAccountEmail is not required and will be removed after 12th June 2025.
 	ServiceAccountEmail string
 	ServiceAccountToken string
 	// Deprecated: retry options were removed to reduce complexity of the client. If this functionality is needed, you can provide your own custom HTTP client.

--- a/core/clients/token_flow.go
+++ b/core/clients/token_flow.go
@@ -19,6 +19,7 @@ type TokenFlow struct {
 
 // TokenFlowConfig is the flow config
 type TokenFlowConfig struct {
+	// Deprecated: ServiceAccountEmail is not required anymore.
 	ServiceAccountEmail string
 	ServiceAccountToken string
 	// Deprecated: retry options were removed to reduce complexity of the client. If this functionality is needed, you can provide your own custom HTTP client.

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -178,8 +178,9 @@ func WithTokenEndpoint(url string) ConfigurationOption {
 // WithServiceAccountEmail returns a ConfigurationOption that sets the service account email
 //
 // Deprecated: WithServiceAccountEmail is not required and will be removed after 12th June 2025.
-func WithServiceAccountEmail(_ string) ConfigurationOption {
-	return func(_ *Configuration) error {
+func WithServiceAccountEmail(serviceAccountEmail string) ConfigurationOption {
+	return func(config *Configuration) error {
+		config.ServiceAccountEmail = serviceAccountEmail
 		return nil
 	}
 }

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -81,7 +81,7 @@ type Configuration struct {
 	UserAgent             string            `json:"userAgent,omitempty"`
 	Debug                 bool              `json:"debug,omitempty"`
 	NoAuth                bool              `json:"noAuth,omitempty"`
-	ServiceAccountEmail   string            `json:"serviceAccountEmail,omitempty"` // Deprecated: ServiceAccountEmail is not required anymore.
+	ServiceAccountEmail   string            `json:"serviceAccountEmail,omitempty"` // Deprecated: ServiceAccountEmail is not required and will be removed after 12th June 2025.
 	Token                 string            `json:"token,omitempty"`
 	ServiceAccountKey     string            `json:"serviceAccountKey,omitempty"`
 	PrivateKey            string            `json:"privateKey,omitempty"`
@@ -177,7 +177,7 @@ func WithTokenEndpoint(url string) ConfigurationOption {
 
 // WithServiceAccountEmail returns a ConfigurationOption that sets the service account email
 //
-// Deprecated: WithServiceAccountEmail is not required anymore.
+// Deprecated: WithServiceAccountEmail is not required and will be removed after 12th June 2025.
 func WithServiceAccountEmail(_ string) ConfigurationOption {
 	return func(_ *Configuration) error {
 		return nil

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -81,7 +81,7 @@ type Configuration struct {
 	UserAgent             string            `json:"userAgent,omitempty"`
 	Debug                 bool              `json:"debug,omitempty"`
 	NoAuth                bool              `json:"noAuth,omitempty"`
-	ServiceAccountEmail   string            `json:"serviceAccountEmail,omitempty"`
+	ServiceAccountEmail   string            `json:"serviceAccountEmail,omitempty"` // Deprecated: ServiceAccountEmail is not required anymore.
 	Token                 string            `json:"token,omitempty"`
 	ServiceAccountKey     string            `json:"serviceAccountKey,omitempty"`
 	PrivateKey            string            `json:"privateKey,omitempty"`
@@ -176,9 +176,10 @@ func WithTokenEndpoint(url string) ConfigurationOption {
 }
 
 // WithServiceAccountEmail returns a ConfigurationOption that sets the service account email
-func WithServiceAccountEmail(serviceAccountEmail string) ConfigurationOption {
-	return func(config *Configuration) error {
-		config.ServiceAccountEmail = serviceAccountEmail
+//
+// Deprecated: WithServiceAccountEmail is not required anymore.
+func WithServiceAccountEmail(_ string) ConfigurationOption {
+	return func(_ *Configuration) error {
 		return nil
 	}
 }
@@ -319,7 +320,6 @@ func WithCustomConfiguration(cfg *Configuration) ConfigurationOption {
 		config.NoAuth = cfg.NoAuth
 		config.Token = cfg.Token
 		config.ServiceAccountKey = cfg.ServiceAccountKey
-		config.ServiceAccountEmail = cfg.ServiceAccountEmail
 		config.ServiceAccountKeyPath = cfg.ServiceAccountKeyPath
 		config.PrivateKey = cfg.PrivateKey
 		config.PrivateKeyPath = cfg.PrivateKeyPath


### PR DESCRIPTION
Deprecated service_account_email config, because it is not required and could be also extracted from the JWT if needed
