### PR TITLE
Region adjustment

### DIFF
--- a/core/CHANGELOG.md
+++ b/core/CHANGELOG.md
@@ -1,3 +1,9 @@
+## v0.15.0 (2025-01-02)
+
+- **Breaking Change:**: `ConfigureRegion` returns an error if a region is specified for a global URL.
+
+STACKIT will move to a new way of specifying regions, where the region is provided as a function argument instead of being set in the client configuration. Once all services have migrated, the methods to specify the region in the client configuration will be removed.
+
 ## v0.14.0 (2024-10-10)
 
 - **Feature:**: Added `IntermediateStateReached` to `AsyncActionHandler` that can be used to check for an intermediate state when executing the wait function of a wait handler.

--- a/core/config/config_test.go
+++ b/core/config/config_test.go
@@ -113,7 +113,27 @@ func TestConfigureRegion(t *testing.T) {
 			isValid: true,
 		},
 		{
-			desc: "valid_deprecated_global_with_specified_region",
+			desc: "invalid_global_default_with_region",
+			cfg: &Configuration{
+				Region: "eu01",
+				Servers: ServerConfigurations{
+					ServerConfiguration{
+						URL: "https://some-api.api.stackit.cloud",
+						Variables: map[string]ServerVariable{
+							"region": {
+								DefaultValue: "global",
+								EnumValues:   []string{},
+							},
+						},
+					},
+				},
+			},
+			regionEnvVar:    "",
+			expectedServers: nil,
+			isValid:         false,
+		},
+		{
+			desc: "invalid_deprecated_global_with_specified_region",
 			cfg: &Configuration{
 				Region: "eu01",
 				Servers: ServerConfigurations{
@@ -128,13 +148,9 @@ func TestConfigureRegion(t *testing.T) {
 					},
 				},
 			},
-			regionEnvVar: "",
-			expectedServers: ServerConfigurations{
-				ServerConfiguration{
-					URL: "https://some-api.api.stackit.cloud",
-				},
-			},
-			isValid: true,
+			regionEnvVar:    "",
+			expectedServers: nil,
+			isValid:         false,
 		},
 		{
 			desc: "env_var_valid_region",


### PR DESCRIPTION
STACKIT will move to a new way of specifying regions with v1. Instead of providing the region in the URL directly it is provided via path parameter. Once all services have migrated, the methods to specify the region in the client configuration will be removed.