### PR TITLE
Fix test runner for sdk

### DIFF
--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -27,6 +27,8 @@ const (
 	privateKeyPathCredentialType        credentialType = "private_key_path"
 )
 
+var userHomeDir = os.UserHomeDir
+
 // SetupAuth sets up authentication based on the configuration. The different options are
 // custom authentication, no authentication, explicit key flow, explicit token flow or default authentication
 func SetupAuth(cfg *config.Configuration) (rt http.RoundTripper, err error) {
@@ -195,7 +197,7 @@ func readCredentialsFile(path string) (*Credentials, error) {
 		customPath, customPathSet := os.LookupEnv("STACKIT_CREDENTIALS_PATH")
 		if !customPathSet || customPath == "" {
 			path = credentialsFilePath
-			home, err := os.UserHomeDir()
+			home, err := userHomeDir()
 			if err != nil {
 				return nil, fmt.Errorf("getting home directory: %w", err)
 			}

--- a/core/auth/auth_test.go
+++ b/core/auth/auth_test.go
@@ -456,6 +456,8 @@ func TestKeyAuth(t *testing.T) {
 			configuredPrivateKey: string(configuredPrivateKey),
 			expectedPrivateKey:   string(configuredPrivateKey),
 			isValid:              true,
+			homeDir:              func(t *testing.T) string { return t.TempDir() },
+
 		},
 		{
 			desc:               "included_private_key",
@@ -463,6 +465,8 @@ func TestKeyAuth(t *testing.T) {
 			includedPrivateKey: &includedPrivateKey,
 			expectedPrivateKey: includedPrivateKey,
 			isValid:            true,
+			homeDir:              func(t *testing.T) string { return t.TempDir() },
+
 		},
 		{
 			desc:                 "empty_configured_use_included_private_key",
@@ -471,6 +475,8 @@ func TestKeyAuth(t *testing.T) {
 			configuredPrivateKey: "",
 			expectedPrivateKey:   includedPrivateKey,
 			isValid:              true,
+			homeDir:              func(t *testing.T) string { return t.TempDir() },
+
 		},
 		{
 			desc:                 "configured_over_included_private_key",
@@ -479,6 +485,8 @@ func TestKeyAuth(t *testing.T) {
 			configuredPrivateKey: configuredPrivateKey,
 			expectedPrivateKey:   configuredPrivateKey,
 			isValid:              true,
+			homeDir:              func(t *testing.T) string { return t.TempDir() },
+
 		},
 		{
 			desc:                 "no_sa_key",
@@ -492,6 +500,7 @@ func TestKeyAuth(t *testing.T) {
 			serviceAccountKey:    fixtureServiceAccountKey(),
 			configuredPrivateKey: "",
 			isValid:              false,
+			homeDir:              func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			desc:                 "no_keys",
@@ -790,6 +799,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			},
 			wantErr:     false,
 			expectedKey: "key",
+			userHomeDir: func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			name: "cfg_sa_key_path",
@@ -798,6 +808,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			},
 			wantErr:     false,
 			expectedKey: "key",
+			userHomeDir: func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			name:                        "env_sa_key_path",
@@ -805,6 +816,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			envServiceAccountKeyPathSet: true,
 			wantErr:                     false,
 			expectedKey:                 "key",
+			userHomeDir: func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			name:                "credentials_file_sa_key_path",
@@ -812,6 +824,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			credentialsFilePath: "test_resources/test_credentials_foo.json",
 			wantErr:             false,
 			expectedKey:         "foo_key",
+			userHomeDir: func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			name: "cfg_sa_key_precedes_path",
@@ -821,6 +834,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			},
 			wantErr:     false,
 			expectedKey: "cfg_key",
+			userHomeDir: func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			name: "cfg_sa_key_precedes_env",
@@ -830,6 +844,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			envServiceAccountKeyPathSet: true,
 			wantErr:                     false,
 			expectedKey:                 "cfg_key",
+			userHomeDir: func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			name: "cfg_sa_key_precedes_creds_file",
@@ -839,6 +854,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			credentialsFilePath: "test_resources/test_credentials_foo.json",
 			wantErr:             false,
 			expectedKey:         "cfg_key",
+			userHomeDir: func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			name:                        "env_sa_key_precedes_creds_file",
@@ -846,6 +862,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			envServiceAccountKeyPathSet: true,
 			credentialsFilePath:         "test_resources/test_credentials_foo.json",
 			wantErr:                     false,
+			userHomeDir: func(t *testing.T) string { return t.TempDir() },
 			expectedKey:                 "key",
 		},
 		{

--- a/core/auth/auth_test.go
+++ b/core/auth/auth_test.go
@@ -457,7 +457,6 @@ func TestKeyAuth(t *testing.T) {
 			expectedPrivateKey:   string(configuredPrivateKey),
 			isValid:              true,
 			homeDir:              func(t *testing.T) string { return t.TempDir() },
-
 		},
 		{
 			desc:               "included_private_key",
@@ -465,8 +464,7 @@ func TestKeyAuth(t *testing.T) {
 			includedPrivateKey: &includedPrivateKey,
 			expectedPrivateKey: includedPrivateKey,
 			isValid:            true,
-			homeDir:              func(t *testing.T) string { return t.TempDir() },
-
+			homeDir:            func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			desc:                 "empty_configured_use_included_private_key",
@@ -476,7 +474,6 @@ func TestKeyAuth(t *testing.T) {
 			expectedPrivateKey:   includedPrivateKey,
 			isValid:              true,
 			homeDir:              func(t *testing.T) string { return t.TempDir() },
-
 		},
 		{
 			desc:                 "configured_over_included_private_key",
@@ -486,7 +483,6 @@ func TestKeyAuth(t *testing.T) {
 			expectedPrivateKey:   configuredPrivateKey,
 			isValid:              true,
 			homeDir:              func(t *testing.T) string { return t.TempDir() },
-
 		},
 		{
 			desc:                 "no_sa_key",
@@ -816,7 +812,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			envServiceAccountKeyPathSet: true,
 			wantErr:                     false,
 			expectedKey:                 "key",
-			userHomeDir: func(t *testing.T) string { return t.TempDir() },
+			userHomeDir:                 func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			name:                "credentials_file_sa_key_path",
@@ -824,7 +820,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			credentialsFilePath: "test_resources/test_credentials_foo.json",
 			wantErr:             false,
 			expectedKey:         "foo_key",
-			userHomeDir: func(t *testing.T) string { return t.TempDir() },
+			userHomeDir:         func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			name: "cfg_sa_key_precedes_path",
@@ -844,7 +840,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			envServiceAccountKeyPathSet: true,
 			wantErr:                     false,
 			expectedKey:                 "cfg_key",
-			userHomeDir: func(t *testing.T) string { return t.TempDir() },
+			userHomeDir:                 func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			name: "cfg_sa_key_precedes_creds_file",
@@ -854,7 +850,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			credentialsFilePath: "test_resources/test_credentials_foo.json",
 			wantErr:             false,
 			expectedKey:         "cfg_key",
-			userHomeDir: func(t *testing.T) string { return t.TempDir() },
+			userHomeDir:         func(t *testing.T) string { return t.TempDir() },
 		},
 		{
 			name:                        "env_sa_key_precedes_creds_file",
@@ -862,7 +858,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 			envServiceAccountKeyPathSet: true,
 			credentialsFilePath:         "test_resources/test_credentials_foo.json",
 			wantErr:                     false,
-			userHomeDir: func(t *testing.T) string { return t.TempDir() },
+			userHomeDir:                 func(t *testing.T) string { return t.TempDir() },
 			expectedKey:                 "key",
 		},
 		{

--- a/core/auth/auth_test.go
+++ b/core/auth/auth_test.go
@@ -503,6 +503,7 @@ func TestKeyAuth(t *testing.T) {
 			t.Setenv("STACKIT_SERVICE_ACCOUNT_KEY_PATH", "")
 			t.Setenv("STACKIT_PRIVATE_KEY", "")
 			t.Setenv("STACKIT_PRIVATE_KEY_PATH", "")
+			t.Setenv("HOME", t.TempDir())
 
 			var saKey string
 			if test.serviceAccountKey != nil {
@@ -843,6 +844,7 @@ func TestGetServiceAccountKey(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
 			t.Setenv("STACKIT_CREDENTIALS_PATH", test.credentialsFilePath)
 
 			if test.envServiceAccountKeyPathSet {


### PR DESCRIPTION
Encapsulate the retrieval of the home directory. Otherwise the testcases will start to interfere with the real users home directory (this cannot be redefined platform-agnostic within go). The cause of this issue is, that service account keys are automatically searched in $HOME/.stackit/credentials.json which interferes with the testcases