### PR TITLE
Feat: increase timeouts for iaas handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,9 @@
   - **Feature:** Add method to list all public ip ranges: `ListPublicIpRanges`
   - Add size attribute to image model
   - Add CPU architecture attribute to image config model
-- `serviceenablement: [v0.6.0](services/serviceenablement/CHANGELOG.md#v060-2025-02-27)
+- `iaas`: [v0.21.1](services/iaas/CHANGELOG.md#v0211-2025-03-02)
+  - Increase Timeouts for volume and network wait handlers
+- `serviceenablement`: [v0.6.0](services/serviceenablement/CHANGELOG.md#v060-2025-02-27)
   - **Breaking Change:** The region is no longer specified within the client configuration. Instead, the region must be passed as a parameter to any region-specific request.
 
 

--- a/services/iaas/CHANGELOG.md
+++ b/services/iaas/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v0.21.1 (2025-03-02)
+
+- Increase Timeouts for volume and network wait handlers
+
 ## v0.21.0 (2025-02-27)
 
 - **Feature:** Add method to list all public ip ranges: `ListPublicIpRanges`
@@ -5,6 +9,7 @@
 - Add CPU architecture attribute to image config model
 
 ## v0.20.0 (2025-02-21)
+
 - **New:** Minimal go version is now Go 1.21
 
 ## v0.19.0 (2024-12-20)

--- a/services/iaas/wait/wait.go
+++ b/services/iaas/wait/wait.go
@@ -188,7 +188,7 @@ func CreateVolumeWaitHandler(ctx context.Context, a APIClientInterface, projectI
 		}
 		return false, volume, nil
 	})
-	handler.SetTimeout(10 * time.Minute)
+	handler.SetTimeout(30 * time.Minute)
 	return handler
 }
 
@@ -216,7 +216,7 @@ func DeleteVolumeWaitHandler(ctx context.Context, a APIClientInterface, projectI
 		}
 		return true, nil, nil
 	})
-	handler.SetTimeout(10 * time.Minute)
+	handler.SetTimeout(30 * time.Minute)
 	return handler
 }
 
@@ -521,7 +521,7 @@ func AddVolumeToServerWaitHandler(ctx context.Context, a APIClientInterface, pro
 		}
 		return false, nil, nil
 	})
-	handler.SetTimeout(10 * time.Minute)
+	handler.SetTimeout(15 * time.Minute)
 	return handler
 }
 
@@ -546,7 +546,7 @@ func RemoveVolumeFromServerWaitHandler(ctx context.Context, a APIClientInterface
 		}
 		return true, nil, nil
 	})
-	handler.SetTimeout(10 * time.Minute)
+	handler.SetTimeout(15 * time.Minute)
 	return handler
 }
 

--- a/services/iaas/wait/wait.go
+++ b/services/iaas/wait/wait.go
@@ -63,7 +63,7 @@ func CreateNetworkAreaWaitHandler(ctx context.Context, a APIClientInterface, org
 		}
 		return false, area, nil
 	})
-	handler.SetTimeout(10 * time.Minute)
+	handler.SetTimeout(15 * time.Minute)
 	return handler
 }
 
@@ -84,7 +84,7 @@ func UpdateNetworkAreaWaitHandler(ctx context.Context, a APIClientInterface, org
 		return false, area, nil
 	})
 	handler.SetSleepBeforeWait(2 * time.Second)
-	handler.SetTimeout(10 * time.Minute)
+	handler.SetTimeout(15 * time.Minute)
 	return handler
 }
 
@@ -104,7 +104,7 @@ func DeleteNetworkAreaWaitHandler(ctx context.Context, a APIClientInterface, org
 		}
 		return true, nil, nil
 	})
-	handler.SetTimeout(10 * time.Minute)
+	handler.SetTimeout(15 * time.Minute)
 	return handler
 }
 
@@ -125,7 +125,7 @@ func CreateNetworkWaitHandler(ctx context.Context, a APIClientInterface, project
 		return false, network, nil
 	})
 	handler.SetSleepBeforeWait(2 * time.Second)
-	handler.SetTimeout(10 * time.Minute)
+	handler.SetTimeout(15 * time.Minute)
 	return handler
 }
 
@@ -146,7 +146,7 @@ func UpdateNetworkWaitHandler(ctx context.Context, a APIClientInterface, project
 		return false, network, nil
 	})
 	handler.SetSleepBeforeWait(2 * time.Second)
-	handler.SetTimeout(10 * time.Minute)
+	handler.SetTimeout(15 * time.Minute)
 	return handler
 }
 
@@ -166,7 +166,7 @@ func DeleteNetworkWaitHandler(ctx context.Context, a APIClientInterface, project
 		}
 		return true, nil, nil
 	})
-	handler.SetTimeout(10 * time.Minute)
+	handler.SetTimeout(15 * time.Minute)
 	return handler
 }
 


### PR DESCRIPTION
In this PR, I've adjusted the default timeout handlers for creating IaaS resources to accommodate the STACKIT Terraform provider's requirements. I've increased the timeouts for longer creation times, such as when provisioning volumes for Windows servers, which typically exceed 10 minutes.