### PR TITLE
add wait handlers for custom domains and distributions

### DIFF
--- a/services/cdn/wait/wait.go
+++ b/services/cdn/wait/wait.go
@@ -98,3 +98,4 @@ func DeleteDistributionWaitHandler(ctx context.Context, api APIClientInterface, 
 	handler.SetTimeout(10 * time.Minute)
 	return handler
 }
+

--- a/services/cdn/wait/wait_test.go
+++ b/services/cdn/wait/wait_test.go
@@ -334,3 +334,4 @@ func TestDeleteDistributionWaitHandler(t *testing.T) {
 		})
 	}
 }
+


### PR DESCRIPTION
## Description

Add wait handlers for CDN resources https://jira.schwarz/browse/STACKITCDN-716

I just saw that a wait handler was already added, please consider this contribution as extending the existing handler with handlers also for custom domains

## Checklist

- [ ] Issue was linked above
- [ ] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-go/blob/783b7fa78e41d072a3ff08e246a13f1bef5aa764/services/dns/api_default.go#L9))
- [ ] Changelogs
    - [ ] Changelog in the root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/CHANGELOG.md))
    - [ ] Changelog(s) of the service(s) were adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/services/dns/CHANGELOG.md))
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
