### PR TITLE
add wait handlers for custom domains and distributions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 ## Release (2025-XX-YY)
+  - `cdn`: [v0.3.0](services/cdn/CHANGELOG.md#v030-2025-04-04)
+    - **New:** Add waiter for creation of `CustomDomain`
+
+## Release (2025-XX-YY)
 - `cdn`: [v0.2.0](services/cdn/CHANGELOG.md#v020-2025-04-01)
   - **API enhancement:** Provide waiter infrastructure
 - `logme`: 

--- a/patch
+++ b/patch
@@ -1,0 +1,23 @@
+diff --git a/CHANGELOG.md b/CHANGELOG.md
+index 2c8562e1..649d463b 100644
+--- a/CHANGELOG.md
++++ b/CHANGELOG.md
+@@ -1,3 +1,7 @@
++## Release (2025-XX-YY)
++  - `cdn`: [v0.3.0](services/cdn/CHANGELOG.md#v030-2025-04-04)
++    - **New:** Add waiter for creation of `CustomDomain`
++
+ ## Release (2025-XX-YY)
+ - `cdn`: [v0.2.0](services/cdn/CHANGELOG.md#v020-2025-04-01)
+   - **API enhancement:** Provide waiter infrastructure
+diff --git a/services/cdn/CHANGELOG.md b/services/cdn/CHANGELOG.md
+index dd315f01..b8e57e59 100644
+--- a/services/cdn/CHANGELOG.md
++++ b/services/cdn/CHANGELOG.md
+@@ -1,3 +1,6 @@
++## v0.3.0 (2025-04-04)
++- **New:** Add waiter for creation of `CustomDomain`
++
+ ## v0.2.0 (2025-04-01)
+ - **API enhancement:** Provide waiter infrastructure
+ 

--- a/services/cdn/CHANGELOG.md
+++ b/services/cdn/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.3.0 (2025-04-04)
+- **New:** Add waiter for creation of `CustomDomain`
+
 ## v0.2.0 (2025-04-01)
 - **API enhancement:** Provide waiter infrastructure
 

--- a/services/cdn/go.mod
+++ b/services/cdn/go.mod
@@ -3,6 +3,7 @@ module github.com/stackitcloud/stackit-sdk-go/services/cdn
 go 1.21
 
 require (
+	github.com/google/go-cmp v0.7.0
 	github.com/google/uuid v1.6.0
 	github.com/stackitcloud/stackit-sdk-go/core v0.16.2
 )

--- a/services/cdn/wait/wait.go
+++ b/services/cdn/wait/wait.go
@@ -13,16 +13,17 @@ import (
 )
 
 const (
-	DistributionStateCreating = "CREATING"
-	DistributionStateActive   = "ACTIVE"
-	DistributionStateUpdating = "UPDATING"
-	DistributionStateDeleting = "DELETING"
-	DistributionStateError    = "ERROR"
+	DistributionStatusCreating = "CREATING"
+	DistributionStatusActive   = "ACTIVE"
+	DistributionStatusUpdating = "UPDATING"
+	DistributionStatusDeleting = "DELETING"
+	DistributionStatusError    = "ERROR"
 )
 
 // Interfaces needed for tests
 type APIClientInterface interface {
 	GetDistributionExecute(ctx context.Context, projectId string, distributionId string) (*cdn.GetDistributionResponse, error)
+	GetCustomDomainExecute(ctx context.Context, projectId string, distributionId string, domain string) (*cdn.GetCustomDomainResponse, error)
 }
 
 func CreateDistributionPoolWaitHandler(ctx context.Context, api APIClientInterface, projectId, distributionId string) *wait.AsyncActionHandler[cdn.GetDistributionResponse] {
@@ -39,17 +40,21 @@ func CreateDistributionPoolWaitHandler(ctx context.Context, api APIClientInterfa
 		}
 		if *distribution.Distribution.Id == distributionId {
 			switch *distribution.Distribution.Status {
-			case DistributionStateActive:
-				return true, distribution, err
+			case DistributionStatusActive:
+				return true, distribution, nil
+			case DistributionStatusCreating, DistributionStatusUpdating:
+				return false, nil, nil
+			case DistributionStatusDeleting:
+				return true, nil, fmt.Errorf("creating CDN distribution failed")
+			case DistributionStatusError:
+				return true, nil, fmt.Errorf("creating CDN distribution failed")
 			default:
-				return false, distribution, err
+				return true, nil, fmt.Errorf("CDNDistributionWaitHandler: unexpected status %s", *distribution.Distribution.Status)
 			}
 		}
-
 		return false, nil, nil
 	})
-
-	handler.SetTimeout(10 * time.Minute)
+	handler.SetTimeout(1 * time.Minute)
 	return handler
 }
 
@@ -67,7 +72,7 @@ func UpdateDistributionWaitHandler(ctx context.Context, api APIClientInterface, 
 		}
 		if *distribution.Distribution.Id == distributionId {
 			switch *distribution.Distribution.Status {
-			case DistributionStateActive:
+			case DistributionStatusActive:
 				return true, distribution, err
 			default:
 				return false, distribution, err
@@ -84,17 +89,62 @@ func UpdateDistributionWaitHandler(ctx context.Context, api APIClientInterface, 
 func DeleteDistributionWaitHandler(ctx context.Context, api APIClientInterface, projectId, distributionId string) *wait.AsyncActionHandler[cdn.GetDistributionResponse] {
 	handler := wait.New(func() (waitFinished bool, distribution *cdn.GetDistributionResponse, err error) {
 		distribution, err = api.GetDistributionExecute(ctx, projectId, distributionId)
-		if err != nil {
-			var oapiError *oapierror.GenericOpenAPIError
-			if errors.As(err, &oapiError) {
-				if statusCode := oapiError.StatusCode; statusCode == http.StatusNotFound || statusCode == http.StatusGone {
-					return true, distribution, nil
-				}
-			}
-		}
-		return false, nil, nil
-	})
 
-	handler.SetTimeout(10 * time.Minute)
+		// the distribution is still gettable, e.g. not deleted
+		if err == nil {
+			return false, nil, nil
+		}
+		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			return true, nil, nil
+		}
+		return false, nil, err
+	})
+	handler.SetTimeout(30 * time.Second)
+	return handler
+}
+
+func CreateCDNCustomDomainWaitHandler(ctx context.Context, a APIClientInterface, projectId, distributionId, domain string) *wait.AsyncActionHandler[cdn.CustomDomain] {
+	handler := wait.New(func() (waitFinished bool, response *cdn.CustomDomain, err error) {
+		resp, err := a.GetCustomDomainExecute(ctx, projectId, distributionId, domain)
+		if err != nil {
+			return false, nil, err
+		}
+		if resp == nil || resp.CustomDomain == nil || resp.CustomDomain.Status == nil {
+			return false, nil, errors.New("CDNDistributionWaitHandler: status or custom domain missing in response")
+		}
+
+		switch *resp.CustomDomain.Status {
+		case cdn.DOMAINSTATUS_ACTIVE:
+			return true, resp.CustomDomain, nil
+		case cdn.DOMAINSTATUS_CREATING, cdn.DOMAINSTATUS_UPDATING:
+			return false, nil, nil
+		case cdn.DOMAINSTATUS_DELETING:
+			return true, nil, fmt.Errorf("creating CDN custom domain failed")
+		case cdn.DOMAINSTATUS_ERROR:
+			return true, nil, fmt.Errorf("creating CDN custom domain failed")
+		default:
+			return true, nil, fmt.Errorf("CDNCustomDomainWaitHandler: unexpected status %s", *resp.CustomDomain.Status)
+		}
+	})
+	handler.SetTimeout(1 * time.Minute)
+	return handler
+}
+
+func DeleteCDNCustomDomainWaitHandler(ctx context.Context, a APIClientInterface, projectId, distributionId, domain string) *wait.AsyncActionHandler[cdn.CustomDomain] {
+	handler := wait.New(func() (waitFinished bool, response *cdn.CustomDomain, err error) {
+		_, err = a.GetCustomDomainExecute(ctx, projectId, distributionId, domain)
+
+		// the custom domain is still gettable, e.g. not deleted
+		if err == nil {
+			return false, nil, nil
+		}
+		oapiErr, ok := err.(*oapierror.GenericOpenAPIError) //nolint:errorlint //complaining that error.As should be used to catch wrapped errors, but this error should not be wrapped
+		if ok && oapiErr.StatusCode == http.StatusNotFound {
+			return true, nil, nil
+		}
+		return false, nil, err
+	})
+	handler.SetTimeout(30 * time.Second)
 	return handler
 }


### PR DESCRIPTION
## Description

Add wait handlers for CDN resources https://jira.schwarz/browse/STACKITCDN-716

I just saw that a wait handler was already added, please consider this contribution as extending the existing handler with handlers also for custom domains

## Checklist

- [x] Issue was linked above
- [x] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-go/blob/783b7fa78e41d072a3ff08e246a13f1bef5aa764/services/dns/api_default.go#L9))
- [x] Changelogs
    - [x] Changelog in the root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/CHANGELOG.md))
    - [x] Changelog(s) of the service(s) were adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/services/dns/CHANGELOG.md))
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
