### PR TITLE
chore: Add make help command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,39 +3,64 @@ SCRIPTS_BASE          ?= $(ROOT_DIR)/scripts
 GOLANG_CI_YAML_PATH   ?= ${ROOT_DIR}/golang-ci.yaml
 GOLANG_CI_ARGS        ?= --allow-parallel-runners --timeout=5m --config=${GOLANG_CI_YAML_PATH}
 
+##
+# Console Colors
+##
+GREEN  := $(shell printf "\033[0;32m")
+YELLOW := $(shell printf "\033[0;33m")
+WHITE  := $(shell printf "\033[0;37m")
+CYAN   := $(shell printf "\033[0;36m")
+RESET  := $(shell printf "\033[0m")
+
+
+##
+# Targets
+##
+.PHONY: help
+help: ## show this help.
+	@echo "Project: stackit-sdk-go"
+	@echo 'Usage:'
+	@echo "  ${GREEN}make${RESET} ${YELLOW}<target>${RESET}"
+	@echo ''
+	@echo 'Targets:'
+	@awk 'BEGIN {FS = ":.*?## "} { \
+		if (/^[a-zA-Z_-]+:.*?##.*$$/) {printf "  ${GREEN}%-21s${YELLOW}%s${RESET}\n", $$1, $$2} \
+		else if (/^## .*$$/) {printf "  ${CYAN}%s${RESET}\n", substr($$1,4)} \
+		}' $(MAKEFILE_LIST) | sort
+
 # SETUP AND TOOL INITIALIZATION TASKS
-project-help:
+project-help: ## Show help for the project
 	@$(SCRIPTS_BASE)/project.sh help
 
-project-tools:
+project-tools: ## Install project tools
 	@$(SCRIPTS_BASE)/project.sh tools
 
 # LINT
-lint-golangci-lint:
+lint-golangci-lint: ## Lint Go code
 	@echo ">> Linting with golangci-lint"
 	@$(SCRIPTS_BASE)/lint-golangci-lint.sh "${skip-non-generated-files}" "${service}"
 
-lint-scripts:
+lint-scripts: ## Lint scripts
 	@echo ">> Linting scripts"
 	@cd ${ROOT_DIR}/scripts && golangci-lint run ${GOLANG_CI_ARGS}
 
-sync-tidy:
+sync-tidy: ## Sync and tidy dependencies
 	@echo ">> Syncing and tidying dependencies"
 	@$(SCRIPTS_BASE)/sync-tidy.sh
 
-lint: sync-tidy
+lint: sync-tidy ## Lint all code
 	@$(MAKE) --no-print-directory lint-golangci-lint skip-non-generated-files=${skip-non-generated-files} service=${service}
 
 # TEST
-test-go:
+test-go: ## Run Go tests
 	@echo ">> Running Go tests"
 	@$(SCRIPTS_BASE)/test-go.sh "${skip-non-generated-files}" "${service}"
 
-test-scripts:
+test-scripts: ## Run tests for scripts
 	@echo ">> Running Go tests for scripts"
 	@go test $(ROOT_DIR)/scripts/... ${GOTEST_ARGS}
 
-test:
+test: ## Run all tests
 	@$(MAKE) --no-print-directory test-go skip-non-generated-files=${skip-non-generated-files} service=${service}
 
 # AUTOMATIC TAG
@@ -45,4 +70,3 @@ sdk-tag-services:
 
 sdk-tag-core: 
 	@go run $(SCRIPTS_BASE)/automatic_tag.go --update-type ${update-type} --ssh-private-key-file-path ${ssh-private-key-file-path} --target core;
-	

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ RESET  := $(shell printf "\033[0m")
 # Targets
 ##
 .PHONY: help
-help: ## show this help.
+help: ## Show this help
 	@echo "Project: stackit-sdk-go"
 	@echo 'Usage:'
 	@echo "  ${GREEN}make${RESET} ${YELLOW}<target>${RESET}"


### PR DESCRIPTION
## Description


Minimalistic `make help` command to get the info with targets are availible without looking through the whole Makefile.

```
Project: stackit-sdk-go
Usage:
  make <target>

Targets:
  help                 show this help.
  lint                 Lint all code
  lint-golangci-lint   Lint Go code
  lint-scripts         Lint scripts
  project-help         Show help for the project
  project-tools        Install project tools
  sync-tidy            Sync and tidy dependencies
  test                 Run all tests
  test-go              Run Go tests
  test-scripts         Run tests for scripts
```

## Checklist

- [ ] Issue was linked above
- [ ] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-go/blob/783b7fa78e41d072a3ff08e246a13f1bef5aa764/services/dns/api_default.go#L9))
- [ ] Changelogs
    - [ ] Changelog in the root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/CHANGELOG.md))
    - [ ] Changelog(s) of the service(s) were adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/services/dns/CHANGELOG.md))
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
