### PR TITLE
feat: add volume backup waiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Release (2025-YY-XX)
+- `iaas`: [v0.24.0](services/iaas/CHANGELOG.md#v0240-2025-06-02)
+  - **Feature:** Add waiters for async operations: `CreateBackupWaitHandler`, `DeleteBackupWaitHandler`, `RestoreBackupWaitHandler`
 - `core`: [v0.17.2](core/CHANGELOG.md#v0172-2025-05-22)
   - **Bugfix:** Access tokens generated via key flow authentication are refreshed 5 seconds before expiration to prevent timing issues with upstream systems which could lead to unexpected 401 error responses
 - `alb`: [v0.4.1](services/alb/CHANGELOG.md#v041-2025-06-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Release (2025-YY-XX)
 - `iaas`: [v0.24.0](services/iaas/CHANGELOG.md#v0240-2025-06-02)
   - **Feature:** Add waiters for async operations: `CreateBackupWaitHandler`, `DeleteBackupWaitHandler`, `RestoreBackupWaitHandler`
+  - **Feature:** Add Waiters for async operations: `CreateSnapshotWaitHandler`, `DeleteSnapshotWaitHandler`
 - `core`: [v0.17.2](core/CHANGELOG.md#v0172-2025-05-22)
   - **Bugfix:** Access tokens generated via key flow authentication are refreshed 5 seconds before expiration to prevent timing issues with upstream systems which could lead to unexpected 401 error responses
 - `alb`: [v0.4.1](services/alb/CHANGELOG.md#v041-2025-06-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Release (2025-YY-XX)
-- `iaas`: [v0.24.0](services/iaas/CHANGELOG.md#v0240-2025-06-02)
+- `iaas`: [v0.24.0](services/iaas/CHANGELOG.md#v0240-2025-06-05)
   - **Feature:** Add waiters for async operations: `CreateBackupWaitHandler`, `DeleteBackupWaitHandler`, `RestoreBackupWaitHandler`
   - **Feature:** Add Waiters for async operations: `CreateSnapshotWaitHandler`, `DeleteSnapshotWaitHandler`
 - `core`: [v0.17.2](core/CHANGELOG.md#v0172-2025-05-22)

--- a/services/iaas/CHANGELOG.md
+++ b/services/iaas/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v0.24.0 (2025-06-02)
 - **Feature:** Add waiters for async operations: `CreateBackupWaitHandler`, `DeleteBackupWaitHandler`, `RestoreBackupWaitHandler`
+- **Feature:** Add Waiters for async operations: `CreateSnapshotWaitHandler`, `DeleteSnapshotWaitHandler`
 
 ## v0.23.0 (2025-05-15)
 - **Breaking change:** Introduce interfaces for `APIClient` and the request structs

--- a/services/iaas/CHANGELOG.md
+++ b/services/iaas/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.24.0 (2025-06-02)
+- **Feature:** Add waiters for async operations: `CreateBackupWaitHandler`, `DeleteBackupWaitHandler`, `RestoreBackupWaitHandler`
+
 ## v0.23.0 (2025-05-15)
 - **Breaking change:** Introduce interfaces for `APIClient` and the request structs
 

--- a/services/iaas/CHANGELOG.md
+++ b/services/iaas/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v0.24.0 (2025-06-02)
+## v0.24.0 (2025-06-05)
 - **Feature:** Add waiters for async operations: `CreateBackupWaitHandler`, `DeleteBackupWaitHandler`, `RestoreBackupWaitHandler`
 - **Feature:** Add Waiters for async operations: `CreateSnapshotWaitHandler`, `DeleteSnapshotWaitHandler`
 

--- a/services/iaas/client.go
+++ b/services/iaas/client.go
@@ -524,7 +524,9 @@ func newStrictDecoder(data []byte) *json.Decoder {
 
 // Set request body from an interface{}
 func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err error) {
-	bodyBuf = &bytes.Buffer{}
+	if bodyBuf == nil {
+		bodyBuf = &bytes.Buffer{}
+	}
 
 	if reader, ok := body.(io.Reader); ok {
 		_, err = bodyBuf.ReadFrom(reader)

--- a/services/iaas/client.go
+++ b/services/iaas/client.go
@@ -524,9 +524,7 @@ func newStrictDecoder(data []byte) *json.Decoder {
 
 // Set request body from an interface{}
 func setBody(body interface{}, contentType string) (bodyBuf *bytes.Buffer, err error) {
-	if bodyBuf == nil {
-		bodyBuf = &bytes.Buffer{}
-	}
+	bodyBuf = &bytes.Buffer{}
 
 	if reader, ok := body.(io.Reader); ok {
 		_, err = bodyBuf.ReadFrom(reader)

--- a/services/iaas/wait/wait.go
+++ b/services/iaas/wait/wait.go
@@ -36,7 +36,6 @@ const (
 
 	XRequestIDHeader = "X-Request-Id"
 
-	// Backup status constants
 	BackupAvailableStatus = "AVAILABLE"
 	BackupRestoringStatus = "RESTORING"
 	BackupDeletingStatus  = "DELETING"
@@ -611,7 +610,7 @@ func CreateBackupWaitHandler(ctx context.Context, a APIClientInterface, projectI
 	handler := wait.New(func() (waitFinished bool, response *iaas.Backup, err error) {
 		backup, err := a.GetBackupExecute(ctx, projectId, backupId)
 		if err != nil {
-			return true, backup, err // TODO: true/false Testcase
+			return true, backup, err // TODO: include in Testcase?
 		}
 		if backup.Id == nil || backup.Status == nil {
 			return true, backup, fmt.Errorf("create failed for backup with id %s, the response is not valid: the id or the status are missing", backupId)
@@ -620,7 +619,7 @@ func CreateBackupWaitHandler(ctx context.Context, a APIClientInterface, projectI
 			return true, backup, nil
 		}
 		if *backup.Id == backupId && *backup.Status == ErrorStatus {
-			return true, backup, fmt.Errorf("create failed for backup with id %s", backupId, *backup.Status)
+			return true, backup, fmt.Errorf("create failed for backup with id %s", backupId)
 		}
 		return false, backup, nil
 	})
@@ -671,7 +670,7 @@ func RestoreBackupWaitHandler(ctx context.Context, a APIClientInterface, project
 		}
 		if *backup.Id == backupId && *backup.Status == ErrorStatus {
 			if backup.Status != nil {
-				return true, backup, fmt.Errorf("restore failed for backup with id %s: %s", backupId, *backup.Status)
+				return true, backup, fmt.Errorf("restore failed for backup with id %s", backupId)
 			}
 			return true, backup, fmt.Errorf("restore failed for backup with id %s", backupId)
 		}

--- a/services/iaas/wait/wait.go
+++ b/services/iaas/wait/wait.go
@@ -14,25 +14,35 @@ import (
 )
 
 const (
-	CreatedStatus     = "CREATED"
-	UpdatedStatus     = "UPDATED"
-	DeletedStatus     = "DELETED"
-	FailedStatus      = "FAILED"
-	DeallocatedStatus = "DEALLOCATED"
-	AvailableStatus   = "AVAILABLE"
-	ActiveStatus      = "ACTIVE"
-	ResizingStatus    = "RESIZING"
-	InactiveStatus    = "INACTIVE"
-	RescueStatus      = "RESCUE"
-	RestoringStatus   = "RESTORING"
-	DeletingStatus    = "DELETING"
-	ErrorStatus       = "ERROR"
+	CreateSuccess         = "CREATED"
+	VolumeAvailableStatus = "AVAILABLE"
+	DeleteSuccess         = "DELETED"
 
-	CreateAction = "CREATE"
-	UpdateAction = "UPDATE"
-	DeleteAction = "DELETE"
+	ErrorStatus = "ERROR"
+
+	ServerActiveStatus      = "ACTIVE"
+	ServerResizingStatus    = "RESIZING"
+	ServerInactiveStatus    = "INACTIVE"
+	ServerDeallocatedStatus = "DEALLOCATED"
+	ServerRescueStatus      = "RESCUE"
+
+	ImageAvailableStatus = "AVAILABLE"
+
+	RequestCreateAction  = "CREATE"
+	RequestUpdateAction  = "UPDATE"
+	RequestDeleteAction  = "DELETE"
+	RequestCreatedStatus = "CREATED"
+	RequestUpdatedStatus = "UPDATED"
+	RequestDeletedStatus = "DELETED"
+	RequestFailedStatus  = "FAILED"
 
 	XRequestIDHeader = "X-Request-Id"
+
+	BackupAvailableStatus = "AVAILABLE"
+	BackupRestoringStatus = "RESTORING"
+	BackupDeletingStatus  = "DELETING"
+
+	SnapshotAvailableStatus = "AVAILABLE"
 )
 
 // Interfaces needed for tests
@@ -58,7 +68,7 @@ func CreateNetworkAreaWaitHandler(ctx context.Context, a APIClientInterface, org
 		if area.AreaId == nil || area.State == nil {
 			return false, area, fmt.Errorf("create failed for network area with id %s, the response is not valid: the id or the state are missing", areaId)
 		}
-		if *area.AreaId == areaId && *area.State == CreatedStatus {
+		if *area.AreaId == areaId && *area.State == CreateSuccess {
 			return true, area, nil
 		}
 		return false, area, nil
@@ -78,7 +88,7 @@ func UpdateNetworkAreaWaitHandler(ctx context.Context, a APIClientInterface, org
 			return false, nil, fmt.Errorf("update failed for network area with id %s, the response is not valid: the id or the state are missing", areaId)
 		}
 		// The state returns to "CREATED" after a successful update is completed
-		if *area.AreaId == areaId && *area.State == CreatedStatus {
+		if *area.AreaId == areaId && *area.State == CreateSuccess {
 			return true, area, nil
 		}
 		return false, area, nil
@@ -119,7 +129,7 @@ func CreateNetworkWaitHandler(ctx context.Context, a APIClientInterface, project
 			return false, network, fmt.Errorf("crate failed for network with id %s, the response is not valid: the id or the state are missing", networkId)
 		}
 		// The state returns to "CREATED" after a successful creation is completed
-		if *network.NetworkId == networkId && *network.State == CreatedStatus {
+		if *network.NetworkId == networkId && *network.State == CreateSuccess {
 			return true, network, nil
 		}
 		return false, network, nil
@@ -140,7 +150,7 @@ func UpdateNetworkWaitHandler(ctx context.Context, a APIClientInterface, project
 			return false, network, fmt.Errorf("update failed for network with id %s, the response is not valid: the id or the state are missing", networkId)
 		}
 		// The state returns to "CREATED" after a successful update is completed
-		if *network.NetworkId == networkId && *network.State == CreatedStatus {
+		if *network.NetworkId == networkId && *network.State == CreateSuccess {
 			return true, network, nil
 		}
 		return false, network, nil
@@ -180,7 +190,7 @@ func CreateVolumeWaitHandler(ctx context.Context, a APIClientInterface, projectI
 		if volume.Id == nil || volume.Status == nil {
 			return false, volume, fmt.Errorf("create failed for volume with id %s, the response is not valid: the id or the status are missing", volumeId)
 		}
-		if *volume.Id == volumeId && *volume.Status == AvailableStatus {
+		if *volume.Id == volumeId && *volume.Status == VolumeAvailableStatus {
 			return true, volume, nil
 		}
 		if *volume.Id == volumeId && *volume.Status == ErrorStatus {
@@ -201,7 +211,7 @@ func DeleteVolumeWaitHandler(ctx context.Context, a APIClientInterface, projectI
 				if volume.Id == nil || volume.Status == nil {
 					return false, volume, fmt.Errorf("delete failed for volume with id %s, the response is not valid: the id or the status are missing", volumeId)
 				}
-				if *volume.Id == volumeId && *volume.Status == DeletedStatus {
+				if *volume.Id == volumeId && *volume.Status == DeleteSuccess {
 					return true, volume, nil
 				}
 			}
@@ -230,7 +240,7 @@ func CreateServerWaitHandler(ctx context.Context, a APIClientInterface, projectI
 		if server.Id == nil || server.Status == nil {
 			return false, server, fmt.Errorf("create failed for server with id %s, the response is not valid: the id or the status are missing", serverId)
 		}
-		if *server.Id == serverId && *server.Status == ActiveStatus {
+		if *server.Id == serverId && *server.Status == ServerActiveStatus {
 			return true, server, nil
 		}
 		if *server.Id == serverId && *server.Status == ErrorStatus {
@@ -266,14 +276,14 @@ func ResizeServerWaitHandler(ctx context.Context, a APIClientInterface, projectI
 		}
 
 		if !h.IntermediateStateReached {
-			if *server.Id == serverId && *server.Status == ResizingStatus {
+			if *server.Id == serverId && *server.Status == ServerResizingStatus {
 				h.IntermediateStateReached = true
 				return false, server, nil
 			}
 			return false, server, nil
 		}
 
-		if *server.Id == serverId && *server.Status == ActiveStatus {
+		if *server.Id == serverId && *server.Status == ServerActiveStatus {
 			return true, server, nil
 		}
 
@@ -292,7 +302,7 @@ func DeleteServerWaitHandler(ctx context.Context, a APIClientInterface, projectI
 				if server.Id == nil || server.Status == nil {
 					return false, server, fmt.Errorf("delete failed for server with id %s, the response is not valid: the id or the status are missing", serverId)
 				}
-				if *server.Id == serverId && *server.Status == DeletedStatus {
+				if *server.Id == serverId && *server.Status == DeleteSuccess {
 					return true, server, nil
 				}
 			}
@@ -321,7 +331,7 @@ func StartServerWaitHandler(ctx context.Context, a APIClientInterface, projectId
 		if server.Id == nil || server.Status == nil {
 			return false, server, fmt.Errorf("start failed for server with id %s, the response is not valid: the id or the status are missing", serverId)
 		}
-		if *server.Id == serverId && *server.Status == ActiveStatus {
+		if *server.Id == serverId && *server.Status == ServerActiveStatus {
 			return true, server, nil
 		}
 		if *server.Id == serverId && *server.Status == ErrorStatus {
@@ -346,7 +356,7 @@ func StopServerWaitHandler(ctx context.Context, a APIClientInterface, projectId,
 		if server.Id == nil || server.Status == nil {
 			return false, server, fmt.Errorf("stop failed for server with id %s, the response is not valid: the id or the status are missing", serverId)
 		}
-		if *server.Id == serverId && *server.Status == InactiveStatus {
+		if *server.Id == serverId && *server.Status == ServerInactiveStatus {
 			return true, server, nil
 		}
 		if *server.Id == serverId && *server.Status == ErrorStatus {
@@ -371,7 +381,7 @@ func DeallocateServerWaitHandler(ctx context.Context, a APIClientInterface, proj
 		if server.Id == nil || server.Status == nil {
 			return false, server, fmt.Errorf("deallocate failed for server with id %s, the response is not valid: the id or the status are missing", serverId)
 		}
-		if *server.Id == serverId && *server.Status == DeallocatedStatus {
+		if *server.Id == serverId && *server.Status == ServerDeallocatedStatus {
 			return true, server, nil
 		}
 		if *server.Id == serverId && *server.Status == ErrorStatus {
@@ -396,7 +406,7 @@ func RescueServerWaitHandler(ctx context.Context, a APIClientInterface, projectI
 		if server.Id == nil || server.Status == nil {
 			return false, server, fmt.Errorf("rescue failed for server with id %s, the response is not valid: the id or the status are missing", serverId)
 		}
-		if *server.Id == serverId && *server.Status == RescueStatus {
+		if *server.Id == serverId && *server.Status == ServerRescueStatus {
 			return true, server, nil
 		}
 		if *server.Id == serverId && *server.Status == ErrorStatus {
@@ -421,7 +431,7 @@ func UnrescueServerWaitHandler(ctx context.Context, a APIClientInterface, projec
 		if server.Id == nil || server.Status == nil {
 			return false, server, fmt.Errorf("unrescue failed for server with id %s, the response is not valid: the id or the status are missing", serverId)
 		}
-		if *server.Id == serverId && *server.Status == ActiveStatus {
+		if *server.Id == serverId && *server.Status == ServerActiveStatus {
 			return true, server, nil
 		}
 		if *server.Id == serverId && *server.Status == ErrorStatus {
@@ -471,23 +481,23 @@ func ProjectRequestWaitHandler(ctx context.Context, a APIClientInterface, projec
 		}
 
 		switch *request.RequestAction {
-		case CreateAction:
-			if *request.Status == CreatedStatus {
+		case RequestCreateAction:
+			if *request.Status == RequestCreatedStatus {
 				return true, request, nil
 			}
-		case UpdateAction:
-			if *request.Status == UpdatedStatus {
+		case RequestUpdateAction:
+			if *request.Status == RequestUpdatedStatus {
 				return true, request, nil
 			}
-		case DeleteAction:
-			if *request.Status == DeletedStatus {
+		case RequestDeleteAction:
+			if *request.Status == RequestDeletedStatus {
 				return true, request, nil
 			}
 		default:
 			return false, request, fmt.Errorf("request failed for request with id %s, the request action %s is not supported", requestId, *request.RequestAction)
 		}
 
-		if *request.Status == FailedStatus {
+		if *request.Status == RequestFailedStatus {
 			return true, request, fmt.Errorf("request failed for request with id %s", requestId)
 		}
 
@@ -560,7 +570,7 @@ func UploadImageWaitHandler(ctx context.Context, a APIClientInterface, projectId
 		if image.Id == nil || image.Status == nil {
 			return false, image, fmt.Errorf("upload failed for image with id %s, the response is not valid: the id or the status are missing", imageId)
 		}
-		if *image.Id == imageId && *image.Status == AvailableStatus {
+		if *image.Id == imageId && *image.Status == ImageAvailableStatus {
 			return true, image, nil
 		}
 		if *image.Id == imageId && *image.Status == ErrorStatus {
@@ -581,7 +591,7 @@ func DeleteImageWaitHandler(ctx context.Context, a APIClientInterface, projectId
 				if image.Id == nil || image.Status == nil {
 					return false, image, fmt.Errorf("delete failed for image with id %s, the response is not valid: the id or the status are missing", imageId)
 				}
-				if *image.Id == imageId && *image.Status == DeletedStatus {
+				if *image.Id == imageId && *image.Status == DeleteSuccess {
 					return true, image, nil
 				}
 			}
@@ -609,7 +619,7 @@ func CreateBackupWaitHandler(ctx context.Context, a APIClientInterface, projectI
 				if backup.Id == nil || backup.Status == nil {
 					return false, backup, fmt.Errorf("create failed for backup with id %s, the response is not valid: the id or the status are missing", backupId)
 				}
-				if *backup.Id == backupId && *backup.Status == AvailableStatus {
+				if *backup.Id == backupId && *backup.Status == BackupAvailableStatus {
 					return true, backup, nil
 				}
 				if *backup.Id == backupId && *backup.Status == ErrorStatus {
@@ -633,7 +643,7 @@ func DeleteBackupWaitHandler(ctx context.Context, a APIClientInterface, projectI
 				if backup.Id == nil || backup.Status == nil {
 					return false, backup, fmt.Errorf("delete failed for backup with id %s, the response is not valid: the id or the status are missing", backupId)
 				}
-				if *backup.Id == backupId && *backup.Status == DeletedStatus {
+				if *backup.Id == backupId && *backup.Status == DeleteSuccess {
 					return true, backup, nil
 				}
 			}
@@ -660,7 +670,7 @@ func RestoreBackupWaitHandler(ctx context.Context, a APIClientInterface, project
 				if backup.Id == nil || backup.Status == nil {
 					return false, backup, fmt.Errorf("restore failed for backup with id %s, the response is not valid: the id or the status are missing", backupId)
 				}
-				if *backup.Id == backupId && *backup.Status == AvailableStatus {
+				if *backup.Id == backupId && *backup.Status == BackupAvailableStatus {
 					return true, backup, nil
 				}
 				if *backup.Id == backupId && *backup.Status == ErrorStatus {
@@ -684,7 +694,7 @@ func CreateSnapshotWaitHandler(ctx context.Context, a APIClientInterface, projec
 				if snapshot.Id == nil || snapshot.Status == nil {
 					return false, snapshot, fmt.Errorf("create failed for snapshot with id %s, the response is not valid: the id or the status are missing", snapshotId)
 				}
-				if *snapshot.Id == snapshotId && *snapshot.Status == AvailableStatus {
+				if *snapshot.Id == snapshotId && *snapshot.Status == SnapshotAvailableStatus {
 					return true, snapshot, nil
 				}
 				if *snapshot.Id == snapshotId && *snapshot.Status == ErrorStatus {
@@ -708,7 +718,7 @@ func DeleteSnapshotWaitHandler(ctx context.Context, a APIClientInterface, projec
 				if snapshot.Id == nil || snapshot.Status == nil {
 					return false, snapshot, fmt.Errorf("delete failed for snapshot with id %s, the response is not valid: the id or the status are missing", snapshotId)
 				}
-				if *snapshot.Id == snapshotId && *snapshot.Status == DeletedStatus {
+				if *snapshot.Id == snapshotId && *snapshot.Status == DeleteSuccess {
 					return true, snapshot, nil
 				}
 			}

--- a/services/iaas/wait/wait_test.go
+++ b/services/iaas/wait/wait_test.go
@@ -104,7 +104,7 @@ func (a *apiClientMocked) GetServerExecute(_ context.Context, _, _ string) (*iaa
 		a.returnResizing = false
 		return &iaas.Server{
 			Id:     utils.Ptr("sid"),
-			Status: utils.Ptr(ResizingStatus),
+			Status: utils.Ptr(ServerResizingStatus),
 		}, nil
 	}
 
@@ -213,7 +213,7 @@ func TestCreateNetworkAreaWaitHandler(t *testing.T) {
 		{
 			desc:          "create_succeeded",
 			getFails:      false,
-			resourceState: CreatedStatus,
+			resourceState: CreateSuccess,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -272,7 +272,7 @@ func TestUpdateNetworkAreaWaitHandler(t *testing.T) {
 		{
 			desc:          "update_succeeded",
 			getFails:      false,
-			resourceState: CreatedStatus,
+			resourceState: CreateSuccess,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -392,7 +392,7 @@ func TestCreateNetworkWaitHandler(t *testing.T) {
 		{
 			desc:          "create_succeeded",
 			getFails:      false,
-			resourceState: CreatedStatus,
+			resourceState: CreateSuccess,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -451,7 +451,7 @@ func TestUpdateNetworkWaitHandler(t *testing.T) {
 		{
 			desc:          "update_succeeded",
 			getFails:      false,
-			resourceState: CreatedStatus,
+			resourceState: CreateSuccess,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -571,7 +571,7 @@ func TestCreateVolumeWaitHandler(t *testing.T) {
 		{
 			desc:          "create_succeeded",
 			getFails:      false,
-			resourceState: AvailableStatus,
+			resourceState: VolumeAvailableStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -698,7 +698,7 @@ func TestCreateServerWaitHandler(t *testing.T) {
 		{
 			desc:          "create_succeeded",
 			getFails:      false,
-			resourceState: ActiveStatus,
+			resourceState: ServerActiveStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -827,7 +827,7 @@ func TestResizeServerWaitHandler(t *testing.T) {
 			desc:               "resize_succeeded",
 			getFails:           false,
 			returnResizing:     true,
-			finalResourceState: ActiveStatus,
+			finalResourceState: ServerActiveStatus,
 			wantErr:            false,
 			wantResp:           true,
 		},
@@ -835,7 +835,7 @@ func TestResizeServerWaitHandler(t *testing.T) {
 			desc:               "resizing_status_is_never_returned",
 			getFails:           false,
 			returnResizing:     false,
-			finalResourceState: ActiveStatus,
+			finalResourceState: ServerActiveStatus,
 			wantErr:            true,
 			wantResp:           true,
 		},
@@ -903,7 +903,7 @@ func TestStartServerWaitHandler(t *testing.T) {
 		{
 			desc:          "start_succeeded",
 			getFails:      false,
-			resourceState: ActiveStatus,
+			resourceState: ServerActiveStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -969,7 +969,7 @@ func TestStopServerWaitHandler(t *testing.T) {
 		{
 			desc:          "stop_succeeded",
 			getFails:      false,
-			resourceState: InactiveStatus,
+			resourceState: ServerInactiveStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -1035,7 +1035,7 @@ func TestDeallocateServerWaitHandler(t *testing.T) {
 		{
 			desc:          "deallocate_succeeded",
 			getFails:      false,
-			resourceState: DeallocatedStatus,
+			resourceState: ServerDeallocatedStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -1101,7 +1101,7 @@ func TestRescueServerWaitHandler(t *testing.T) {
 		{
 			desc:          "rescue_succeeded",
 			getFails:      false,
-			resourceState: RescueStatus,
+			resourceState: ServerRescueStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -1167,7 +1167,7 @@ func TestUnrescueServerWaitHandler(t *testing.T) {
 		{
 			desc:          "unrescue_succeeded",
 			getFails:      false,
-			resourceState: ActiveStatus,
+			resourceState: ServerActiveStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -1234,24 +1234,24 @@ func TestProjectRequestWaitHandler(t *testing.T) {
 		{
 			desc:          "create_succeeded",
 			getFails:      false,
-			requestAction: CreateAction,
-			requestState:  CreatedStatus,
+			requestAction: RequestCreateAction,
+			requestState:  RequestCreatedStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
 		{
 			desc:          "update_succeeded",
 			getFails:      false,
-			requestAction: UpdateAction,
-			requestState:  UpdatedStatus,
+			requestAction: RequestUpdateAction,
+			requestState:  RequestUpdatedStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
 		{
 			desc:          "delete_succeeded",
 			getFails:      false,
-			requestAction: DeleteAction,
-			requestState:  DeletedStatus,
+			requestAction: RequestDeleteAction,
+			requestState:  RequestDeletedStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -1265,7 +1265,7 @@ func TestProjectRequestWaitHandler(t *testing.T) {
 		{
 			desc:          "error_status",
 			getFails:      false,
-			requestAction: CreateAction,
+			requestAction: RequestCreateAction,
 			requestState:  ErrorStatus,
 			wantErr:       true,
 			wantResp:      true,
@@ -1280,7 +1280,7 @@ func TestProjectRequestWaitHandler(t *testing.T) {
 		{
 			desc:          "timeout",
 			getFails:      false,
-			requestAction: CreateAction,
+			requestAction: RequestCreateAction,
 			requestState:  "ANOTHER Status",
 			wantErr:       true,
 			wantResp:      true,
@@ -1444,7 +1444,7 @@ func TestUploadImageWaitHandler(t *testing.T) {
 		{
 			desc:          "upload_succeeded",
 			getFails:      false,
-			resourceState: AvailableStatus,
+			resourceState: ImageAvailableStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -1556,7 +1556,7 @@ func TestCreateBackupWaitHandler(t *testing.T) {
 		{
 			desc:          "create_succeeded",
 			getFails:      false,
-			resourceState: AvailableStatus,
+			resourceState: BackupAvailableStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -1673,7 +1673,7 @@ func TestRestoreBackupWaitHandler(t *testing.T) {
 		{
 			desc:          "restore_succeeded",
 			getFails:      false,
-			resourceState: AvailableStatus,
+			resourceState: BackupAvailableStatus,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -1738,7 +1738,7 @@ func TestCreateSnapshotWaitHandler(t *testing.T) {
 		{
 			desc:          "create_succeeded",
 			getFails:      false,
-			resourceState: CreatedStatus,
+			resourceState: CreateSuccess,
 			wantErr:       false,
 			wantResp:      true,
 		},
@@ -1803,7 +1803,7 @@ func TestDeleteSnapshotWaitHandler(t *testing.T) {
 		{
 			desc:          "delete_succeeded",
 			getFails:      false,
-			resourceState: DeletedStatus,
+			resourceState: DeleteSuccess,
 			wantErr:       false,
 			wantResp:      true,
 		},


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

This PR creates the waiters (creation, Deletion, Restoring) to complete the volume backup api onboarding.

## Checklist

- [x] Issue was linked above
- [x] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-go/blob/783b7fa78e41d072a3ff08e246a13f1bef5aa764/services/dns/api_default.go#L9))
- [x] Changelogs
    - [x] Changelog in the root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/CHANGELOG.md))
    - [x] Changelog(s) of the service(s) were adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/services/dns/CHANGELOG.md))
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
