### PR TITLE
feat: add snapshot wait handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Release (2025-YY-XX)
 - `core`: [v0.17.2](core/CHANGELOG.md#v0172-2025-05-22)
   - **Bugfix:** Access tokens generated via key flow authentication are refreshed 5 seconds before expiration to prevent timing issues with upstream systems which could lead to unexpected 401 error responses
+- `iaas`: [v0.25.0](services/iaas/CHANGELOG.md#v0250-2025-06-02)
+  - **Feature:** Add waiters for async operations: `CreateSnapshotWaitHandler` and `DeleteSnapshotWaitHandler`
 
 ## Release (2025-05-15)
 - `alb`:

--- a/services/iaas/CHANGELOG.md
+++ b/services/iaas/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v0.25.0 (2025-06-02)
+- **Feature:** Add waiters for async operations: `CreateSnapshotWaitHandler` and `DeleteSnapshotWaitHandler`
+
 ## v0.23.0 (2025-05-15)
 - **Breaking change:** Introduce interfaces for `APIClient` and the request structs
 


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

This PR creates the waiters (creation, Deletion) to complete the snapshot api onboarding.

## Checklist

- [x] Issue was linked above
- [x] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-go/blob/783b7fa78e41d072a3ff08e246a13f1bef5aa764/services/dns/api_default.go#L9))
- [x] Changelogs
    - [x] Changelog in the root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/CHANGELOG.md))
    - [x] Changelog(s) of the service(s) were adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/services/dns/CHANGELOG.md))
- [x] Code format was applied: `make fmt`
- [x] Examples were added / adjusted (see `examples/` directory)
- [x] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
