### PR TITLE
feat: Support setting federated token as env

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,13 +147,18 @@ For each authentication method, the try order is:
 ```go
 // Using wokload identity federation flow
 config.WithWorkloadIdentityFederationAuth()
-// With the custom path for the external OIDC token
+// With the external OIDC token
+config.WithWorkloadIdentityFederationToken("OIDC Token")
+// OR With the custom path for the external OIDC token
 config.WithWorkloadIdentityFederationPath("/path/to/your/federated/token")
 // For the service account
 config.WithServiceAccountEmail("my-sa@sa-stackit.cloud")
 ```
 **B. Environment Variables**
 ```bash
+# Preferred: provide the external OIDC token directly
+# (has priority over STACKIT_FEDERATED_TOKEN_FILE)
+STACKIT_FEDERATED_TOKEN=<oidc-jwt-token>
 # With the custom path for the external OIDC token
 STACKIT_FEDERATED_TOKEN_FILE=/path/to/your/federated/token
 # For the service account

--- a/core/clients/workload_identity_flow.go
+++ b/core/clients/workload_identity_flow.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -15,6 +16,7 @@ import (
 
 const (
 	clientIDEnv           = "STACKIT_SERVICE_ACCOUNT_EMAIL"
+	FederatedTokenEnv     = "STACKIT_FEDERATED_TOKEN"              //nolint:gosec // This is not a secret, just the env variable name
 	FederatedTokenFileEnv = "STACKIT_FEDERATED_TOKEN_FILE"         //nolint:gosec // This is not a secret, just the env variable name
 	wifTokenEndpointEnv   = "STACKIT_IDP_TOKEN_ENDPOINT"           //nolint:gosec // This is not a secret, just the env variable name
 	wifTokenExpirationEnv = "STACKIT_IDP_TOKEN_EXPIRATION_SECONDS" //nolint:gosec // This is not a secret, just the env variable name
@@ -134,7 +136,13 @@ func (c *WorkloadIdentityFederationFlow) Init(cfg *WorkloadIdentityFederationFlo
 	}
 
 	if c.config.FederatedTokenFunction == nil {
-		c.config.FederatedTokenFunction = oidcadapters.ReadJWTFromFileSystem(utils.GetEnvOrDefault(FederatedTokenFileEnv, defaultFederatedTokenPath))
+		if token, ok := os.LookupEnv(FederatedTokenEnv); ok {
+			c.config.FederatedTokenFunction = func(_ context.Context) (string, error) {
+				return token, nil
+			}
+		} else {
+			c.config.FederatedTokenFunction = oidcadapters.ReadJWTFromFileSystem(utils.GetEnvOrDefault(FederatedTokenFileEnv, defaultFederatedTokenPath))
+		}
 	}
 
 	c.tokenExpirationLeeway = defaultTokenExpirationLeeway

--- a/core/clients/workload_identity_flow_test.go
+++ b/core/clients/workload_identity_flow_test.go
@@ -25,6 +25,8 @@ func TestWorkloadIdentityFlowInit(t *testing.T) {
 		customTokenUrlEnv    bool
 		tokenExpiration      string
 		validAssertion       bool
+		federatedTokenAsEnv  bool
+		tokenFilePathEnv     string
 		tokenFilePathAsEnv   bool
 		missingTokenFilePath bool
 		wantErr              bool
@@ -52,6 +54,19 @@ func TestWorkloadIdentityFlowInit(t *testing.T) {
 			customTokenUrlEnv:  true,
 			validAssertion:     true,
 			wantErr:            false,
+		},
+		{
+			name:                "ok using federated token from env",
+			clientID:            "test@stackit.cloud",
+			federatedTokenAsEnv: true,
+			wantErr:             false,
+		},
+		{
+			name:                "federated token env has priority over invalid token file",
+			clientID:            "test@stackit.cloud",
+			federatedTokenAsEnv: true,
+			tokenFilePathEnv:    "/tmp/not-existing-token-file",
+			wantErr:             false,
 		},
 		{
 			name:           "missing client id",
@@ -87,7 +102,19 @@ func TestWorkloadIdentityFlowInit(t *testing.T) {
 				flowConfig.TokenExpiration = tt.tokenExpiration
 			}
 
-			if !tt.missingTokenFilePath {
+			if tt.federatedTokenAsEnv {
+				token, err := signTokenWithSubject("subject", time.Minute)
+				if err != nil {
+					t.Fatalf("failed to create token: %v", err)
+				}
+				t.Setenv("STACKIT_FEDERATED_TOKEN", token)
+			}
+
+			if tt.tokenFilePathEnv != "" {
+				t.Setenv("STACKIT_FEDERATED_TOKEN_FILE", tt.tokenFilePathEnv)
+			}
+
+			if !tt.missingTokenFilePath && !tt.federatedTokenAsEnv {
 				file, err := os.CreateTemp("", "*.token")
 				if err != nil {
 					log.Fatal(err)
@@ -117,6 +144,17 @@ func TestWorkloadIdentityFlowInit(t *testing.T) {
 
 			if err := flow.Init(flowConfig); (err != nil) != tt.wantErr {
 				t.Errorf("KeyFlow.Init() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.federatedTokenAsEnv && !tt.wantErr {
+				tokenFromConfig, err := flow.config.FederatedTokenFunction(context.Background())
+				if err != nil {
+					t.Fatalf("getting federated token from config: %v", err)
+				}
+				tokenFromEnv := os.Getenv("STACKIT_FEDERATED_TOKEN")
+				if tokenFromConfig != tokenFromEnv {
+					t.Errorf("federated token mismatch, want env token")
+				}
 			}
 			if flow.config == nil {
 				t.Error("config is nil")
@@ -156,6 +194,7 @@ func TestWorkloadIdentityFlowRoundTrip(t *testing.T) {
 		clientID       string
 		validAssertion bool
 		injectToken    bool
+		tokenAsEnv     bool
 		wantErr        bool
 	}{
 		{
@@ -176,6 +215,13 @@ func TestWorkloadIdentityFlowRoundTrip(t *testing.T) {
 			clientID:       "test@stackit.cloud",
 			validAssertion: false,
 			wantErr:        true,
+		},
+		{
+			name:           "token from env ok",
+			clientID:       "test@stackit.cloud",
+			validAssertion: true,
+			tokenAsEnv:     true,
+			wantErr:        false,
 		},
 	}
 	for _, tt := range tests {
@@ -268,6 +314,9 @@ func TestWorkloadIdentityFlowRoundTrip(t *testing.T) {
 				flowConfig.FederatedTokenFunction = func(context.Context) (string, error) {
 					return token, nil
 				}
+			} else if tt.tokenAsEnv {
+				t.Setenv("STACKIT_FEDERATED_TOKEN", token)
+				t.Setenv("STACKIT_FEDERATED_TOKEN_FILE", "/tmp/not-existing-token-file")
 			} else {
 				file, err := os.CreateTemp("", "*.token")
 				if err != nil {


### PR DESCRIPTION
## Description

This PR supports setting the federated token directly as env var. This is not really useful for long term workloads but it's quite interesting for CI processes (I need this to support Gitlab in terraform) and I think that adding the default behaviour to the SDK is better than adding the logic in multiple places.

Thanks to this change, if there is an env var `STACKIT_FEDERATED_TOKEN` in the system, it will be used as "raw"
 token, if not, it'll look for `STACKIT_FEDERATED_TOKEN_FILE` as before. Any override done by the SDK caller is respected, this is just a change in default behaviour when missing extra configs

## Checklist

- [ ] Issue was linked above
- [ ] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-go/blob/783b7fa78e41d072a3ff08e246a13f1bef5aa764/services/dns/api_default.go#L9))
- [ ] Changelogs
    - [ ] Changelog in the root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/CHANGELOG.md))
    - [ ] Changelog(s) of the service(s) were adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/services/dns/CHANGELOG.md))
- [ ] VERSION file(s) of the service(s) were adjusted
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
