### PR TITLE
feat(ci): migrate to golangci-lint v2

### DIFF
--- a/core/clients/continuous_refresh_test.go
+++ b/core/clients/continuous_refresh_test.go
@@ -212,7 +212,7 @@ func TestContinuousRefreshTokenConcurrency(t *testing.T) {
 						AccessToken:  newAccessToken,
 						RefreshToken: refreshToken,
 					}
-					responseBody, err := json.Marshal(responseBodyStruct)
+					responseBody, err := json.Marshal(responseBodyStruct) //nolint:gosec // G117: access_token is a standard field name
 					if err != nil {
 						t.Fatalf("Do call: failed to marshal additional response: %v", err)
 					}
@@ -259,7 +259,7 @@ func TestContinuousRefreshTokenConcurrency(t *testing.T) {
 					AccessToken:  accessTokenSecond,
 					RefreshToken: refreshToken,
 				}
-				responseBody, err := json.Marshal(responseBodyStruct)
+				responseBody, err := json.Marshal(responseBodyStruct) //nolint:gosec // G117: access_token is a standard field name
 				if err != nil {
 					t.Fatalf("Do call: failed request to refresh token: marshal access token response: %v", err)
 				}

--- a/core/clients/continuous_refresh_test.go
+++ b/core/clients/continuous_refresh_test.go
@@ -212,7 +212,7 @@ func TestContinuousRefreshTokenConcurrency(t *testing.T) {
 						AccessToken:  newAccessToken,
 						RefreshToken: refreshToken,
 					}
-					responseBody, err := json.Marshal(responseBodyStruct) //nolint:gosec // G117: access_token is a standard field name
+					responseBody, err := json.Marshal(responseBodyStruct)
 					if err != nil {
 						t.Fatalf("Do call: failed to marshal additional response: %v", err)
 					}
@@ -259,7 +259,7 @@ func TestContinuousRefreshTokenConcurrency(t *testing.T) {
 					AccessToken:  accessTokenSecond,
 					RefreshToken: refreshToken,
 				}
-				responseBody, err := json.Marshal(responseBodyStruct) //nolint:gosec // G117: access_token is a standard field name
+				responseBody, err := json.Marshal(responseBodyStruct)
 				if err != nil {
 					t.Fatalf("Do call: failed request to refresh token: marshal access token response: %v", err)
 				}

--- a/core/clients/key_flow.go
+++ b/core/clients/key_flow.go
@@ -183,7 +183,7 @@ func (c *KeyFlow) SetToken(accessToken, refreshToken string) error {
 	c.tokenMutex.Lock()
 	c.token = &TokenResponseBody{
 		AccessToken:  accessToken,
-		ExpiresIn:    int(exp.Time.Unix()),
+		ExpiresIn:    int(exp.Unix()),
 		RefreshToken: refreshToken,
 		Scope:        defaultScope,
 		TokenType:    defaultTokenType,
@@ -334,6 +334,7 @@ func (c *KeyFlow) createAccessToken() (err error) {
 
 // createAccessTokenWithRefreshToken creates an access token using
 // an existing pre-validated refresh token
+//
 // Deprecated: This method will be removed in future versions. Access tokens are going to be refreshed without refresh token.
 // This will be removed after 2026-07-01.
 func (c *KeyFlow) createAccessTokenWithRefreshToken() (err error) {
@@ -391,11 +392,11 @@ func (c *KeyFlow) requestToken(grant, assertion string) (*http.Response, error) 
 	}
 
 	payload := strings.NewReader(body.Encode())
-	req, err := http.NewRequest(http.MethodPost, c.config.TokenUrl, payload)
+	req, err := http.NewRequest(http.MethodPost, c.config.TokenUrl, payload) //nolint:gosec // G704: Tainted URL is expected here
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	return c.authClient.Do(req)
+	return c.authClient.Do(req) //nolint:gosec // G704: Tainted URL is expected here
 }

--- a/core/clients/key_flow.go
+++ b/core/clients/key_flow.go
@@ -392,11 +392,11 @@ func (c *KeyFlow) requestToken(grant, assertion string) (*http.Response, error) 
 	}
 
 	payload := strings.NewReader(body.Encode())
-	req, err := http.NewRequest(http.MethodPost, c.config.TokenUrl, payload) //nolint:gosec // G704: Tainted URL is expected here
+	req, err := http.NewRequest(http.MethodPost, c.config.TokenUrl, payload)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	return c.authClient.Do(req) //nolint:gosec // G704: Tainted URL is expected here
+	return c.authClient.Do(req)
 }

--- a/core/clients/key_flow_test.go
+++ b/core/clients/key_flow_test.go
@@ -463,7 +463,7 @@ func TestKeyFlow_Do(t *testing.T) {
 								TokenType:   "Bearer",
 							}
 
-							if err := json.NewEncoder(res.Body).Encode(token); err != nil { //nolint:gosec // G117: access_token is a standard field name
+							if err := json.NewEncoder(res.Body).Encode(token); err != nil {
 								t.Logf("no error is expected, but got %v", err)
 							}
 

--- a/core/clients/key_flow_test.go
+++ b/core/clients/key_flow_test.go
@@ -104,6 +104,7 @@ func TestKeyFlowInit(t *testing.T) {
 			invalidPrivateKey: true,
 			wantErr:           true,
 		},
+		//nolint:gosec // G101: These are only test values
 		{
 			name: "ok-custom-token-endpoint",
 			serviceAccountKey: fixtureServiceAccountKey(func(s *ServiceAccountKeyResponse) {
@@ -462,7 +463,7 @@ func TestKeyFlow_Do(t *testing.T) {
 								TokenType:   "Bearer",
 							}
 
-							if err := json.NewEncoder(res.Body).Encode(token); err != nil {
+							if err := json.NewEncoder(res.Body).Encode(token); err != nil { //nolint:gosec // G117: access_token is a standard field name
 								t.Logf("no error is expected, but got %v", err)
 							}
 

--- a/core/clients/workload_identity_flow.go
+++ b/core/clients/workload_identity_flow.go
@@ -213,11 +213,11 @@ func (c *WorkloadIdentityFederationFlow) requestToken(clientID, assertion string
 	body.Set("client_id", clientID)
 
 	payload := strings.NewReader(body.Encode())
-	req, err := http.NewRequest(http.MethodPost, c.config.TokenUrl, payload)
+	req, err := http.NewRequest(http.MethodPost, c.config.TokenUrl, payload) //nolint:gosec // G704: Tainted URL is expected here
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	return c.authClient.Do(req)
+	return c.authClient.Do(req) //nolint:gosec // G704: Tainted URL is expected here
 }

--- a/core/clients/workload_identity_flow.go
+++ b/core/clients/workload_identity_flow.go
@@ -213,11 +213,11 @@ func (c *WorkloadIdentityFederationFlow) requestToken(clientID, assertion string
 	body.Set("client_id", clientID)
 
 	payload := strings.NewReader(body.Encode())
-	req, err := http.NewRequest(http.MethodPost, c.config.TokenUrl, payload) //nolint:gosec // G704: Tainted URL is expected here
+	req, err := http.NewRequest(http.MethodPost, c.config.TokenUrl, payload)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	return c.authClient.Do(req) //nolint:gosec // G704: Tainted URL is expected here
+	return c.authClient.Do(req)
 }

--- a/core/clients/workload_identity_flow_test.go
+++ b/core/clients/workload_identity_flow_test.go
@@ -181,7 +181,7 @@ func TestWorkloadIdentityFlowRoundTrip(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			authServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				err := r.ParseForm()
+				err := r.ParseForm() //nolint:gosec // G120: Safe to bypass inside unit tests
 				if err != nil {
 					t.Fatalf("failed to parse form: %v", err)
 				}
@@ -217,7 +217,7 @@ func TestWorkloadIdentityFlowRoundTrip(t *testing.T) {
 					TokenType:   "Bearer",
 				}
 
-				payload, err := json.Marshal(tokenResponse)
+				payload, err := json.Marshal(tokenResponse) //nolint:gosec // G117: access_token is a standard field name
 				if err != nil {
 					t.Fatalf("failed to create token payload: %v", err)
 				}

--- a/core/clients/workload_identity_flow_test.go
+++ b/core/clients/workload_identity_flow_test.go
@@ -217,7 +217,7 @@ func TestWorkloadIdentityFlowRoundTrip(t *testing.T) {
 					TokenType:   "Bearer",
 				}
 
-				payload, err := json.Marshal(tokenResponse) //nolint:gosec // G117: access_token is a standard field name
+				payload, err := json.Marshal(tokenResponse)
 				if err != nil {
 					t.Fatalf("failed to create token payload: %v", err)
 				}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -430,9 +430,9 @@ func (sc ServerConfigurations) URL(index int, variables map[string]string) (stri
 			if !found {
 				return "", fmt.Errorf("the variable %s in the server URL has invalid value %v. Must be %v", name, value, variable.EnumValues)
 			}
-			serverUrl = strings.Replace(serverUrl, "{"+name+"}", value, -1)
+			serverUrl = strings.ReplaceAll(serverUrl, "{"+name+"}", value)
 		} else {
-			serverUrl = strings.Replace(serverUrl, "{"+name+"}", variable.DefaultValue, -1)
+			serverUrl = strings.ReplaceAll(serverUrl, "{"+name+"}", variable.DefaultValue)
 		}
 	}
 	return serverUrl, nil
@@ -554,7 +554,7 @@ func ConfigureRegion(cfg *Configuration) error {
 		}
 		// API is regional (not global)
 		if containsCaseSensitive(availableRegions, cfg.Region) {
-			cfgUrl := strings.Replace(servers[0].URL, "{region}", fmt.Sprintf("%s.", cfg.Region), -1)
+			cfgUrl := strings.ReplaceAll(servers[0].URL, "{region}", fmt.Sprintf("%s.", cfg.Region))
 			cfg.Servers = ServerConfigurations{
 				{
 					URL:         cfgUrl,
@@ -574,7 +574,7 @@ func ConfigureRegion(cfg *Configuration) error {
 	}
 	// If the url is a template, generated using deprecated config.json, the region variable is replaced
 	// If the url is already configured, there is no region variable and it remains the same
-	cfgUrl := strings.Replace(servers[0].URL, "{region}", "", -1)
+	cfgUrl := strings.ReplaceAll(servers[0].URL, "{region}", "")
 	cfg.Servers = ServerConfigurations{
 		{
 			URL:         cfgUrl,

--- a/golang-ci.yaml
+++ b/golang-ci.yaml
@@ -49,6 +49,8 @@ linters:
         - G102 # "Bind to all interfaces" -> since this is normal in k8s
         - G304 # "File path provided as taint input" -> too many false positives
         - G307 # "Deferring unsafe method "Close" on type "io.ReadCloser" -> false positive when calling defer resp.Body.Close()
+        - G117 # "Marshaled struct field xxx (JSON key xxx) matches secret pattern" -> too many false positives, no true positives expected in our code
+        - G704 # "SSRF via taint analysis" -> too many false positives
     misspell:
       # Correct spellings using locale preferences for US or UK.
       # Default is to use a neutral variety of English.
@@ -79,9 +81,6 @@ linters:
         # This ignores all deprecation warnings in the old wait packages while we have the compatibilty layer in place
         path: wait/[^/]+\.go$
         text: "SA1019:"
-    paths:
-      - third_party$
-      - builtin$
 formatters:
   enable:
     - gofmt
@@ -94,6 +93,3 @@ formatters:
         - github.com/stackitcloud/stackit-sdk-go
   exclusions:
     generated: lax
-    paths:
-      - third_party$
-      - builtin$

--- a/golang-ci.yaml
+++ b/golang-ci.yaml
@@ -1,102 +1,99 @@
 # This file contains all available configuration options
 # with their default values.
 
+version: "2"
+
 # options for analysis running
 run:
   # default concurrency is a available CPU number
   concurrency: 4
-
-  # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
-linters-settings:
-  goimports:
-    # put imports beginning with prefix after 3rd-party packages;
-    # it's a comma-separated list of prefixes
-    local-prefixes: github.com/stackitcloud/stackit-sdk-go
-  depguard:
-    rules:
-        main:
-          list-mode: lax # Everything is allowed unless it is denied
-          deny:
-            - pkg: "github.com/stretchr/testify"
-              desc: Do not use a testing framework
-  misspell:
-    # Correct spellings using locale preferences for US or UK.
-    # Default is to use a neutral variety of English.
-    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
-    locale: US
-  golint:
-    min-confidence: 0.8
-  gosec:
-    excludes:
-    # Suppressions: (see https://github.com/securego/gosec#available-rules for details)
-      - G104 # "Audit errors not checked" -> which we don't need and is a badly implemented version of errcheck
-      - G102 # "Bind to all interfaces" -> since this is normal in k8s
-      - G304 # "File path provided as taint input" -> too many false positives
-      - G307 # "Deferring unsafe method "Close" on type "io.ReadCloser" -> false positive when calling defer resp.Body.Close()
-  nakedret:
-    max-func-lines: 0
-  revive:
-    ignore-generated-header: true
-    severity: error
-    # https://github.com/mgechev/revive
-    rules:
-      - name: errorf
-      - name: context-as-argument
-      - name: error-return
-      - name: increment-decrement
-      - name: indent-error-flow
-      - name: superfluous-else
-      - name: unused-parameter
-      - name: unreachable-code
-      - name: atomic
-      - name: empty-lines
-      - name: early-return
-  gocritic:
-    enabled-tags:
-      - performance
-      - style
-      - experimental
-    disabled-checks:
-      - wrapperFunc
-      - typeDefFirst
-      - ifElseChain
-      - dupImport # https://github.com/go-critic/go-critic/issues/845
 linters:
   enable:
-    # https://golangci-lint.run/usage/linters/
-    # default linters
-    - gosimple
-    - govet
-    - ineffassign
-    - staticcheck
-    - typecheck
-    - unused
-    # additional linters
+    - bodyclose
+    - depguard
     - errorlint
+    - forcetypeassert
     - gochecknoinits
     - gocritic
-    - gofmt
-    - goimports
     - gosec
     - misspell
     - nakedret
     - revive
-    - depguard
-    - bodyclose
     - sqlclosecheck
     - wastedassign
-    - forcetypeassert
-    - errcheck
   disable:
     - noctx # false positive: finds errors with http.NewRequest that dont make sense
     - unparam # false positives
-issues:
-  exclude-use-default: false
-  exclude-rules:
-    # This ignores all deprecation warnings in the old wait packages while we have the compatibilty layer in place
-    - path: ^wait/[^/]+\.go$
-      linters:
-        - staticcheck
-      text: "SA1019:" 
-go: 1.25
+  settings:
+    depguard:
+      rules:
+        main:
+          list-mode: lax # Everything is allowed unless it is denied
+          deny:
+            - pkg: github.com/stretchr/testify
+              desc: Do not use a testing framework
+    gocritic:
+      disabled-checks:
+        - wrapperFunc
+        - typeDefFirst
+        - ifElseChain
+        - dupImport # https://github.com/go-critic/go-critic/issues/845
+      enabled-tags:
+        - performance
+        - style
+        - experimental
+    gosec:
+      excludes:
+      # Suppressions: (see https://github.com/securego/gosec#available-rules for details)
+        - G104 # "Audit errors not checked" -> which we don't need and is a badly implemented version of errcheck
+        - G102 # "Bind to all interfaces" -> since this is normal in k8s
+        - G304 # "File path provided as taint input" -> too many false positives
+        - G307 # "Deferring unsafe method "Close" on type "io.ReadCloser" -> false positive when calling defer resp.Body.Close()
+    misspell:
+      # Correct spellings using locale preferences for US or UK.
+      # Default is to use a neutral variety of English.
+      # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+      locale: US
+    nakedret:
+      max-func-lines: 0
+    revive:
+      severity: error
+      # https://github.com/mgechev/revive
+      rules:
+        - name: errorf
+        - name: context-as-argument
+        - name: error-return
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: superfluous-else
+        - name: unused-parameter
+        - name: unreachable-code
+        - name: atomic
+        - name: empty-lines
+        - name: early-return
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - staticcheck
+        # This ignores all deprecation warnings in the old wait packages while we have the compatibilty layer in place
+        path: wait/[^/]+\.go$
+        text: "SA1019:"
+    paths:
+      - third_party$
+      - builtin$
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      # put imports beginning with prefix after 3rd-party packages;
+      # it's a comma-separated list of prefixes
+      local-prefixes:
+        - github.com/stackitcloud/stackit-sdk-go
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$

--- a/scripts/project.sh
+++ b/scripts/project.sh
@@ -16,7 +16,7 @@ elif [ "$action" = "tools" ]; then
 
     go mod download
 
-    go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.62.0
+    go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2
 else
     echo "Invalid action: '$action', please use $0 help for help"
 fi

--- a/services/cdn/wait/wait.go
+++ b/services/cdn/wait/wait.go
@@ -26,6 +26,7 @@ const (
 )
 
 // Interfaces needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInterface interface {
 	GetDistributionExecute(ctx context.Context, projectId string, distributionId string) (*cdn.GetDistributionResponse, error)

--- a/services/dns/wait/wait.go
+++ b/services/dns/wait/wait.go
@@ -25,6 +25,7 @@ const (
 )
 
 // Interfaces needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInterface interface {
 	GetZoneExecute(ctx context.Context, projectId, zoneId string) (*dns.ZoneResponse, error)
@@ -32,6 +33,7 @@ type APIClientInterface interface {
 }
 
 // CreateZoneWaitHandler will wait for zone creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateZoneWaitHandler(ctx context.Context, a APIClientInterface, projectId, instanceId string) *wait.AsyncActionHandler[dns.ZoneResponse] {
 	handler := wait.New(func() (waitFinished bool, response *dns.ZoneResponse, err error) {
@@ -55,6 +57,7 @@ func CreateZoneWaitHandler(ctx context.Context, a APIClientInterface, projectId,
 }
 
 // PartialUpdateZoneWaitHandler will wait for zone update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func PartialUpdateZoneWaitHandler(ctx context.Context, a APIClientInterface, projectId, instanceId string) *wait.AsyncActionHandler[dns.ZoneResponse] {
 	handler := wait.New(func() (waitFinished bool, response *dns.ZoneResponse, err error) {
@@ -79,6 +82,7 @@ func PartialUpdateZoneWaitHandler(ctx context.Context, a APIClientInterface, pro
 
 // DeleteZoneWaitHandler will wait for zone deletion
 // returned interface is nil or *ZoneResponseZone
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteZoneWaitHandler(ctx context.Context, a APIClientInterface, projectId, instanceId string) *wait.AsyncActionHandler[dns.ZoneResponse] {
 	handler := wait.New(func() (waitFinished bool, response *dns.ZoneResponse, err error) {
@@ -102,6 +106,7 @@ func DeleteZoneWaitHandler(ctx context.Context, a APIClientInterface, projectId,
 }
 
 // CreateRecordWaitHandler will wait for recordset creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateRecordSetWaitHandler(ctx context.Context, a APIClientInterface, projectId, instanceId, rrSetId string) *wait.AsyncActionHandler[dns.RecordSetResponse] {
 	handler := wait.New(func() (waitFinished bool, response *dns.RecordSetResponse, err error) {
@@ -125,6 +130,7 @@ func CreateRecordSetWaitHandler(ctx context.Context, a APIClientInterface, proje
 }
 
 // UpdateRecordWaitHandler will wait for recordset update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func PartialUpdateRecordSetWaitHandler(ctx context.Context, a APIClientInterface, projectId, instanceId, rrSetId string) *wait.AsyncActionHandler[dns.RecordSetResponse] {
 	handler := wait.New(func() (waitFinished bool, response *dns.RecordSetResponse, err error) {
@@ -149,6 +155,7 @@ func PartialUpdateRecordSetWaitHandler(ctx context.Context, a APIClientInterface
 
 // DeleteRecordWaitHandler will wait for deletion
 // returned interface is nil or *RecordSetResponse
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteRecordSetWaitHandler(ctx context.Context, a APIClientInterface, projectId, instanceId, rrSetId string) *wait.AsyncActionHandler[dns.RecordSetResponse] {
 	handler := wait.New(func() (waitFinished bool, response *dns.RecordSetResponse, err error) {

--- a/services/git/wait/wait.go
+++ b/services/git/wait/wait.go
@@ -22,6 +22,7 @@ const (
 )
 
 // APIClientInterface Interfaces needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInterface interface {
 	GetInstanceExecute(ctx context.Context, projectId string, instanceId string) (*git.Instance, error)

--- a/services/iaas/v2api/wait/wait.go
+++ b/services/iaas/v2api/wait/wait.go
@@ -466,6 +466,7 @@ func ProjectRequestWaitHandler(ctx context.Context, a iaas.DefaultAPI, projectId
 }
 
 // AddVolumeToServerWaitHandler will wait for a volume to be attached to a server
+//
 // Deprecated: AddVolumeToServerWaitHandler is deprecated and will be removed after November 2026. Please use instead ProjectRequestWaitHandler
 func AddVolumeToServerWaitHandler(ctx context.Context, a iaas.DefaultAPI, projectId, region, serverId, volumeId string) *wait.AsyncActionHandler[iaas.VolumeAttachment] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.VolumeAttachment, err error) {
@@ -495,6 +496,7 @@ func AddVolumeToServerWaitHandler(ctx context.Context, a iaas.DefaultAPI, projec
 }
 
 // RemoveVolumeFromServerWaitHandler will wait for a volume to be attached to a server
+//
 // Deprecated: RemoveVolumeFromServerWaitHandler is deprecated and will be removed after November 2026. Please use instead ProjectRequestWaitHandler
 func RemoveVolumeFromServerWaitHandler(ctx context.Context, a iaas.DefaultAPI, projectId, region, serverId, volumeId string) *wait.AsyncActionHandler[iaas.VolumeAttachment] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.VolumeAttachment, err error) {

--- a/services/iaas/wait/wait.go
+++ b/services/iaas/wait/wait.go
@@ -69,6 +69,7 @@ const (
 )
 
 // Interfaces needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInterface interface {
 	GetNetworkAreaExecute(ctx context.Context, organizationId, areaId string) (*iaas.NetworkArea, error)
@@ -90,6 +91,7 @@ type ResourceManagerAPIClientInterface interface {
 }
 
 // CreateNetworkAreaRegionWaitHandler will wait for network area region creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateNetworkAreaRegionWaitHandler(ctx context.Context, a APIClientInterface, organizationId, areaId, region string) *wait.AsyncActionHandler[iaas.RegionalArea] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.RegionalArea, err error) {
@@ -112,6 +114,7 @@ func CreateNetworkAreaRegionWaitHandler(ctx context.Context, a APIClientInterfac
 }
 
 // DeleteNetworkAreaRegionWaitHandler will wait for network area region deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteNetworkAreaRegionWaitHandler(ctx context.Context, a APIClientInterface, organizationId, areaId, region string) *wait.AsyncActionHandler[iaas.RegionalArea] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.RegionalArea, err error) {
@@ -141,6 +144,7 @@ func DeleteNetworkAreaRegionWaitHandler(ctx context.Context, a APIClientInterfac
 // When the deletion for a project is triggered, the backend starts a workflow in the background which cleans up all resources
 // within a project and deletes the project in each service. When the project is attached to an SNA, the SNA can't be
 // deleted until the workflow inform the IaaS-API that the project is deleted.
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func ReadyForNetworkAreaDeletionWaitHandler(ctx context.Context, a APIClientInterface, r ResourceManagerAPIClientInterface, organizationId, areaId string) *wait.AsyncActionHandler[iaas.ProjectListResponse] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.ProjectListResponse, err error) {
@@ -184,6 +188,7 @@ func ReadyForNetworkAreaDeletionWaitHandler(ctx context.Context, a APIClientInte
 }
 
 // CreateNetworkWaitHandler will wait for network creation using network id
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateNetworkWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, networkId string) *wait.AsyncActionHandler[iaas.Network] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Network, err error) {
@@ -206,6 +211,7 @@ func CreateNetworkWaitHandler(ctx context.Context, a APIClientInterface, project
 }
 
 // UpdateNetworkWaitHandler will wait for network update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func UpdateNetworkWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, networkId string) *wait.AsyncActionHandler[iaas.Network] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Network, err error) {
@@ -228,6 +234,7 @@ func UpdateNetworkWaitHandler(ctx context.Context, a APIClientInterface, project
 }
 
 // DeleteNetworkWaitHandler will wait for network deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteNetworkWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, networkId string) *wait.AsyncActionHandler[iaas.Network] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Network, err error) {
@@ -249,6 +256,7 @@ func DeleteNetworkWaitHandler(ctx context.Context, a APIClientInterface, project
 }
 
 // CreateVolumeWaitHandler will wait for volume creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateVolumeWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, volumeId string) *wait.AsyncActionHandler[iaas.Volume] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Volume, err error) {
@@ -272,6 +280,7 @@ func CreateVolumeWaitHandler(ctx context.Context, a APIClientInterface, projectI
 }
 
 // DeleteVolumeWaitHandler will wait for volume deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteVolumeWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, volumeId string) *wait.AsyncActionHandler[iaas.Volume] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Volume, err error) {
@@ -301,6 +310,7 @@ func DeleteVolumeWaitHandler(ctx context.Context, a APIClientInterface, projectI
 }
 
 // CreateServerWaitHandler will wait for server creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, serverId string) *wait.AsyncActionHandler[iaas.Server] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
@@ -328,6 +338,7 @@ func CreateServerWaitHandler(ctx context.Context, a APIClientInterface, projectI
 
 // ResizeServerWaitHandler will wait for server resize
 // It checks for an intermediate resizing status and only then waits for the server to become active
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func ResizeServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, serverId string) (h *wait.AsyncActionHandler[iaas.Server]) {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
@@ -366,6 +377,7 @@ func ResizeServerWaitHandler(ctx context.Context, a APIClientInterface, projectI
 }
 
 // DeleteServerWaitHandler will wait for volume deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, serverId string) *wait.AsyncActionHandler[iaas.Server] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
@@ -395,6 +407,7 @@ func DeleteServerWaitHandler(ctx context.Context, a APIClientInterface, projectI
 }
 
 // StartServerWaitHandler will wait for server start
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func StartServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, serverId string) *wait.AsyncActionHandler[iaas.Server] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
@@ -421,6 +434,7 @@ func StartServerWaitHandler(ctx context.Context, a APIClientInterface, projectId
 }
 
 // StopServerWaitHandler will wait for server stop
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func StopServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, serverId string) *wait.AsyncActionHandler[iaas.Server] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
@@ -447,6 +461,7 @@ func StopServerWaitHandler(ctx context.Context, a APIClientInterface, projectId,
 }
 
 // DeallocateServerWaitHandler will wait for server deallocation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeallocateServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, serverId string) *wait.AsyncActionHandler[iaas.Server] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
@@ -473,6 +488,7 @@ func DeallocateServerWaitHandler(ctx context.Context, a APIClientInterface, proj
 }
 
 // RescueServerWaitHandler will wait for server rescue
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func RescueServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, serverId string) *wait.AsyncActionHandler[iaas.Server] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
@@ -499,6 +515,7 @@ func RescueServerWaitHandler(ctx context.Context, a APIClientInterface, projectI
 }
 
 // UnrescueServerWaitHandler will wait for server unrescue
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func UnrescueServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, serverId string) *wait.AsyncActionHandler[iaas.Server] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Server, err error) {
@@ -588,6 +605,7 @@ func ProjectRequestWaitHandler(ctx context.Context, a APIClientInterface, projec
 }
 
 // AddVolumeToServerWaitHandler will wait for a volume to be attached to a server
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func AddVolumeToServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, serverId, volumeId string) *wait.AsyncActionHandler[iaas.VolumeAttachment] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.VolumeAttachment, err error) {
@@ -617,6 +635,7 @@ func AddVolumeToServerWaitHandler(ctx context.Context, a APIClientInterface, pro
 }
 
 // RemoveVolumeFromServerWaitHandler will wait for a volume to be attached to a server
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func RemoveVolumeFromServerWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, serverId, volumeId string) *wait.AsyncActionHandler[iaas.VolumeAttachment] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.VolumeAttachment, err error) {
@@ -643,6 +662,7 @@ func RemoveVolumeFromServerWaitHandler(ctx context.Context, a APIClientInterface
 }
 
 // UploadImageWaitHandler will wait for the status image to become AVAILABLE, which indicates the upload of the image has been completed successfully
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func UploadImageWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, imageId string) *wait.AsyncActionHandler[iaas.Image] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Image, err error) {
@@ -666,6 +686,7 @@ func UploadImageWaitHandler(ctx context.Context, a APIClientInterface, projectId
 }
 
 // DeleteImageWaitHandler will wait for image deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteImageWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, imageId string) *wait.AsyncActionHandler[iaas.Image] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Image, err error) {
@@ -695,6 +716,7 @@ func DeleteImageWaitHandler(ctx context.Context, a APIClientInterface, projectId
 }
 
 // CreateBackupWaitHandler will wait for backup creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateBackupWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, backupId string) *wait.AsyncActionHandler[iaas.Backup] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Backup, err error) {
@@ -720,6 +742,7 @@ func CreateBackupWaitHandler(ctx context.Context, a APIClientInterface, projectI
 }
 
 // DeleteBackupWaitHandler will wait for backup deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteBackupWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, backupId string) *wait.AsyncActionHandler[iaas.Backup] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Backup, err error) {
@@ -748,6 +771,7 @@ func DeleteBackupWaitHandler(ctx context.Context, a APIClientInterface, projectI
 }
 
 // RestoreBackupWaitHandler will wait for backup restoration
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func RestoreBackupWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, backupId string) *wait.AsyncActionHandler[iaas.Backup] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Backup, err error) {
@@ -773,6 +797,7 @@ func RestoreBackupWaitHandler(ctx context.Context, a APIClientInterface, project
 }
 
 // CreateSnapshotWaitHandler will wait for snapshot creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateSnapshotWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, snapshotId string) *wait.AsyncActionHandler[iaas.Snapshot] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Snapshot, err error) {
@@ -798,6 +823,7 @@ func CreateSnapshotWaitHandler(ctx context.Context, a APIClientInterface, projec
 }
 
 // DeleteSnapshotWaitHandler will wait for snapshot deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteSnapshotWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, snapshotId string) *wait.AsyncActionHandler[iaas.Snapshot] {
 	handler := wait.New(func() (waitFinished bool, response *iaas.Snapshot, err error) {

--- a/services/loadbalancer/v2api/wait/wait.go
+++ b/services/loadbalancer/v2api/wait/wait.go
@@ -41,7 +41,7 @@ func CreateLoadBalancerWaitHandler(ctx context.Context, a loadbalancer.DefaultAP
 			var sb strings.Builder
 			if r.Errors != nil {
 				for _, err := range r.Errors {
-					sb.WriteString(fmt.Sprintf("%s: %s; ", *err.Type, *err.Description))
+					fmt.Fprintf(&sb, "%s: %s; ", *err.Type, *err.Description)
 				}
 				return "", fmt.Errorf("create failed for instance with name %s, got status %s and errors: %s", instanceName, *r.Status, sb.String())
 			}

--- a/services/loadbalancer/wait/wait.go
+++ b/services/loadbalancer/wait/wait.go
@@ -29,12 +29,14 @@ const (
 var _ APIClientInterface = &loadbalancer.APIClient{}
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInterface interface {
 	GetLoadBalancerExecute(ctx context.Context, projectId, region, name string) (*loadbalancer.LoadBalancer, error)
 }
 
 // CreateLoadBalancerWaitHandler will wait for load balancer creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateLoadBalancerWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, instanceName string) *wait.AsyncActionHandler[loadbalancer.LoadBalancer] {
 	handler := wait.New(func() (waitFinished bool, response *loadbalancer.LoadBalancer, err error) {
@@ -74,6 +76,7 @@ func CreateLoadBalancerWaitHandler(ctx context.Context, a APIClientInterface, pr
 }
 
 // DeleteLoadBalancerWaitHandler will wait for load balancer deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteLoadBalancerWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, instanceId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {

--- a/services/logme/wait/wait.go
+++ b/services/logme/wait/wait.go
@@ -53,18 +53,21 @@ const (
 )
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInstanceInterface interface {
 	GetInstanceExecute(ctx context.Context, projectId, instanceId string) (*logme.Instance, error)
 }
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientCredentialsInterface interface {
 	GetCredentialsExecute(ctx context.Context, projectId, instanceId, credentialsId string) (*logme.CredentialsResponse, error)
 }
 
 // CreateInstanceWaitHandler will wait for instance creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[logme.Instance] {
 	handler := wait.New(func() (waitFinished bool, response *logme.Instance, err error) {
@@ -92,6 +95,7 @@ func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // PartialUpdateInstanceWaitHandler will wait for instance update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[logme.Instance] {
 	handler := wait.New(func() (waitFinished bool, response *logme.Instance, err error) {
@@ -119,6 +123,7 @@ func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceIn
 }
 
 // DeleteInstanceWaitHandler will wait for instance deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {
@@ -152,6 +157,7 @@ func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // CreateCredentialsWaitHandler will wait for credentials creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInterface, projectId, instanceId, credentialsId string) *wait.AsyncActionHandler[logme.CredentialsResponse] {
 	handler := wait.New(func() (waitFinished bool, response *logme.CredentialsResponse, err error) {
@@ -177,6 +183,7 @@ func CreateCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInt
 }
 
 // DeleteCredentialsWaitHandler will wait for credentials deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInterface, projectId, instanceId, credentialsId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {

--- a/services/mariadb/wait/wait.go
+++ b/services/mariadb/wait/wait.go
@@ -53,18 +53,21 @@ const (
 )
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInstanceInterface interface {
 	GetInstanceExecute(ctx context.Context, projectId, instanceId string) (*mariadb.Instance, error)
 }
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientCredentialsInterface interface {
 	GetCredentialsExecute(ctx context.Context, projectId, instanceId, credentialsId string) (*mariadb.CredentialsResponse, error)
 }
 
 // CreateInstanceWaitHandler will wait for instance creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[mariadb.Instance] {
 	handler := wait.New(func() (waitFinished bool, response *mariadb.Instance, err error) {
@@ -92,6 +95,7 @@ func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // PartialUpdateInstanceWaitHandler will wait for instance update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[mariadb.Instance] {
 	handler := wait.New(func() (waitFinished bool, response *mariadb.Instance, err error) {
@@ -119,6 +123,7 @@ func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceIn
 }
 
 // DeleteInstanceWaitHandler will wait for instance deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {
@@ -152,6 +157,7 @@ func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // CreateCredentialsWaitHandler will wait for credentials creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInterface, projectId, instanceId, credentialsId string) *wait.AsyncActionHandler[mariadb.CredentialsResponse] {
 	handler := wait.New(func() (waitFinished bool, response *mariadb.CredentialsResponse, err error) {
@@ -177,6 +183,7 @@ func CreateCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInt
 }
 
 // DeleteCredentialsWaitHandler will wait for credentials deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInterface, projectId, instanceId, credentialsId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {

--- a/services/modelserving/wait/wait.go
+++ b/services/modelserving/wait/wait.go
@@ -44,6 +44,7 @@ func CreateModelServingWaitHandler(ctx context.Context, a APIClientInterface, re
 
 // UpdateModelServingWaitHandler will wait for the model serving auth token to be updated.
 // Eventually it will have a different implementation, but for now it's the same as the create handler.
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func UpdateModelServingWaitHandler(ctx context.Context, a APIClientInterface, region, projectId, tokenId string) *wait.AsyncActionHandler[modelserving.GetTokenResponse] {
 	return CreateModelServingWaitHandler(ctx, a, region, projectId, tokenId)

--- a/services/mongodbflex/wait/wait.go
+++ b/services/mongodbflex/wait/wait.go
@@ -35,6 +35,7 @@ const (
 )
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInstanceInterface interface {
 	GetInstanceExecute(ctx context.Context, projectId, instanceId, region string) (*mongodbflex.InstanceResponse, error)
@@ -42,6 +43,7 @@ type APIClientInstanceInterface interface {
 }
 
 // CreateInstanceWaitHandler will wait for instance creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId, region string) *wait.AsyncActionHandler[mongodbflex.InstanceResponse] {
 	handler := wait.New(func() (waitFinished bool, response *mongodbflex.InstanceResponse, err error) {
@@ -73,6 +75,7 @@ func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // CloneInstanceWaitHandler will wait for instance clone to be created
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CloneInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId, region string) *wait.AsyncActionHandler[mongodbflex.InstanceResponse] {
 	return CreateInstanceWaitHandler(ctx, a, projectId, instanceId, region)
@@ -124,6 +127,7 @@ func RestoreInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterfac
 }
 
 // UpdateInstanceWaitHandler will wait for instance update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func UpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId, region string) *wait.AsyncActionHandler[mongodbflex.InstanceResponse] {
 	handler := wait.New(func() (waitFinished bool, response *mongodbflex.InstanceResponse, err error) {
@@ -154,12 +158,14 @@ func UpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // PartialUpdateInstanceWaitHandler will wait for instance update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId, region string) *wait.AsyncActionHandler[mongodbflex.InstanceResponse] {
 	return UpdateInstanceWaitHandler(ctx, a, projectId, instanceId, region)
 }
 
 // DeleteInstanceWaitHandler will wait for instance deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId, region string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {

--- a/services/objectstorage/wait/wait.go
+++ b/services/objectstorage/wait/wait.go
@@ -12,12 +12,14 @@ import (
 )
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientBucketInterface interface {
 	GetBucketExecute(ctx context.Context, projectId string, region, bucketName string) (*objectstorage.GetBucketResponse, error)
 }
 
 // CreateBucketWaitHandler will wait for bucket creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateBucketWaitHandler(ctx context.Context, a APIClientBucketInterface, projectId, region, bucketName string) *wait.AsyncActionHandler[objectstorage.GetBucketResponse] {
 	handler := wait.New(func() (waitFinished bool, response *objectstorage.GetBucketResponse, err error) {
@@ -32,6 +34,7 @@ func CreateBucketWaitHandler(ctx context.Context, a APIClientBucketInterface, pr
 }
 
 // DeleteBucketWaitHandler will wait for bucket deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteBucketWaitHandler(ctx context.Context, a APIClientBucketInterface, projectId, region, bucketName string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {

--- a/services/observability/wait/wait.go
+++ b/services/observability/wait/wait.go
@@ -25,6 +25,7 @@ const (
 )
 
 // APIClientInterface Interfaces needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInterface interface {
 	GetInstanceExecute(ctx context.Context, instanceId, projectId string) (*observability.GetInstanceResponse, error)
@@ -32,6 +33,7 @@ type APIClientInterface interface {
 }
 
 // CreateInstanceWaitHandler will wait for instance creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateInstanceWaitHandler(ctx context.Context, a APIClientInterface, instanceId, projectId string) *wait.AsyncActionHandler[observability.GetInstanceResponse] {
 	handler := wait.New(func() (waitFinished bool, response *observability.GetInstanceResponse, err error) {
@@ -58,6 +60,7 @@ func CreateInstanceWaitHandler(ctx context.Context, a APIClientInterface, instan
 }
 
 // UpdateInstanceWaitHandler will wait for instance update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func UpdateInstanceWaitHandler(ctx context.Context, a APIClientInterface, instanceId, projectId string) *wait.AsyncActionHandler[observability.GetInstanceResponse] {
 	handler := wait.New(func() (waitFinished bool, response *observability.GetInstanceResponse, err error) {
@@ -85,6 +88,7 @@ func UpdateInstanceWaitHandler(ctx context.Context, a APIClientInterface, instan
 }
 
 // DeleteInstanceWaitHandler will wait for instance deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInterface, instanceId, projectId string) *wait.AsyncActionHandler[observability.GetInstanceResponse] {
 	handler := wait.New(func() (waitFinished bool, response *observability.GetInstanceResponse, err error) {
@@ -111,6 +115,7 @@ func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInterface, instan
 }
 
 // CreateScrapeConfigWaitHandler will wait for scrape config creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateScrapeConfigWaitHandler(ctx context.Context, a APIClientInterface, instanceId, jobName, projectId string) *wait.AsyncActionHandler[observability.ListScrapeConfigsResponse] {
 	handler := wait.New(func() (waitFinished bool, response *observability.ListScrapeConfigsResponse, err error) {
@@ -131,6 +136,7 @@ func CreateScrapeConfigWaitHandler(ctx context.Context, a APIClientInterface, in
 }
 
 // DeleteScrapeConfigWaitHandler will wait for scrape config deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteScrapeConfigWaitHandler(ctx context.Context, a APIClientInterface, instanceId, jobName, projectId string) *wait.AsyncActionHandler[observability.ListScrapeConfigsResponse] {
 	handler := wait.New(func() (waitFinished bool, response *observability.ListScrapeConfigsResponse, err error) {

--- a/services/opensearch/wait/wait.go
+++ b/services/opensearch/wait/wait.go
@@ -52,18 +52,21 @@ const (
 )
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInstanceInterface interface {
 	GetInstanceExecute(ctx context.Context, projectId, instanceId string) (*opensearch.Instance, error)
 }
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientCredentialsInterface interface {
 	GetCredentialsExecute(ctx context.Context, projectId, instanceId, credentialsId string) (*opensearch.CredentialsResponse, error)
 }
 
 // CreateInstanceWaitHandler will wait for instance creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[opensearch.Instance] {
 	handler := wait.New(func() (waitFinished bool, response *opensearch.Instance, err error) {
@@ -91,6 +94,7 @@ func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // PartialUpdateInstanceWaitHandler will wait for instance update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[opensearch.Instance] {
 	handler := wait.New(func() (waitFinished bool, response *opensearch.Instance, err error) {
@@ -118,6 +122,7 @@ func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceIn
 }
 
 // DeleteInstanceWaitHandler will wait for instance deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {
@@ -151,6 +156,7 @@ func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // CreateCredentialsWaitHandler will wait for credentials creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInterface, projectId, instanceId, credentialsId string) *wait.AsyncActionHandler[opensearch.CredentialsResponse] {
 	handler := wait.New(func() (waitFinished bool, response *opensearch.CredentialsResponse, err error) {
@@ -176,6 +182,7 @@ func CreateCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInt
 }
 
 // DeleteCredentialsWaitHandler will wait for credentials deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInterface, projectId, instanceId, credentialsId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {

--- a/services/postgresflex/wait/wait.go
+++ b/services/postgresflex/wait/wait.go
@@ -24,6 +24,7 @@ const (
 )
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInstanceInterface interface {
 	GetInstanceExecute(ctx context.Context, projectId, region, instanceId string) (*postgresflex.InstanceResponse, error)
@@ -31,12 +32,14 @@ type APIClientInstanceInterface interface {
 }
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientUserInterface interface {
 	GetUserExecute(ctx context.Context, projectId, region, instanceId, userId string) (*postgresflex.GetUserResponse, error)
 }
 
 // CreateInstanceWaitHandler will wait for instance creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, region, instanceId string) *wait.AsyncActionHandler[postgresflex.InstanceResponse] {
 	instanceCreated := false
@@ -87,6 +90,7 @@ func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // PartialUpdateInstanceWaitHandler will wait for instance update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, region, instanceId string) *wait.AsyncActionHandler[postgresflex.InstanceResponse] {
 	handler := wait.New(func() (waitFinished bool, response *postgresflex.InstanceResponse, err error) {
@@ -115,6 +119,7 @@ func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceIn
 }
 
 // DeleteInstanceWaitHandler will wait for instance deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, region, instanceId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {
@@ -139,6 +144,7 @@ func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // ForceDeleteInstanceWaitHandler will wait for instance deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func ForceDeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, region, instanceId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {
@@ -160,6 +166,7 @@ func ForceDeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInte
 }
 
 // DeleteUserWaitHandler will wait for delete
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteUserWaitHandler(ctx context.Context, a APIClientUserInterface, projectId, region, instanceId, userId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {

--- a/services/rabbitmq/wait/wait.go
+++ b/services/rabbitmq/wait/wait.go
@@ -52,18 +52,21 @@ const (
 )
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInstanceInterface interface {
 	GetInstanceExecute(ctx context.Context, projectId, instanceId string) (*rabbitmq.Instance, error)
 }
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientCredentialsInterface interface {
 	GetCredentialsExecute(ctx context.Context, projectId, instanceId, credentialsId string) (*rabbitmq.CredentialsResponse, error)
 }
 
 // CreateInstanceWaitHandler will wait for instance creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[rabbitmq.Instance] {
 	handler := wait.New(func() (waitFinished bool, response *rabbitmq.Instance, err error) {
@@ -91,6 +94,7 @@ func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // PartialUpdateInstanceWaitHandler will wait for instance update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[rabbitmq.Instance] {
 	handler := wait.New(func() (waitFinished bool, response *rabbitmq.Instance, err error) {
@@ -118,6 +122,7 @@ func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceIn
 }
 
 // DeleteInstanceWaitHandler will wait for instance deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {
@@ -151,6 +156,7 @@ func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // CreateCredentialsWaitHandler will wait for credentials creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInterface, projectId, instanceId, credentialsId string) *wait.AsyncActionHandler[rabbitmq.CredentialsResponse] {
 	handler := wait.New(func() (waitFinished bool, response *rabbitmq.CredentialsResponse, err error) {
@@ -176,6 +182,7 @@ func CreateCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInt
 }
 
 // DeleteCredentialsWaitHandler will wait for credentials deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInterface, projectId, instanceId, credentialsId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {

--- a/services/redis/wait/wait.go
+++ b/services/redis/wait/wait.go
@@ -52,18 +52,21 @@ const (
 )
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInstanceInterface interface {
 	GetInstanceExecute(ctx context.Context, projectId, instanceId string) (*redis.Instance, error)
 }
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientCredentialsInterface interface {
 	GetCredentialsExecute(ctx context.Context, projectId, instanceId, credentialsId string) (*redis.CredentialsResponse, error)
 }
 
 // CreateInstanceWaitHandler will wait for instance creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[redis.Instance] {
 	handler := wait.New(func() (waitFinished bool, response *redis.Instance, err error) {
@@ -91,6 +94,7 @@ func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // PartialUpdateInstanceWaitHandler will wait for instance update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[redis.Instance] {
 	handler := wait.New(func() (waitFinished bool, response *redis.Instance, err error) {
@@ -118,6 +122,7 @@ func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceIn
 }
 
 // DeleteInstanceWaitHandler will wait for instance deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {
@@ -151,6 +156,7 @@ func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // CreateCredentialsWaitHandler will wait for credentials creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInterface, projectId, instanceId, credentialsId string) *wait.AsyncActionHandler[redis.CredentialsResponse] {
 	handler := wait.New(func() (waitFinished bool, response *redis.CredentialsResponse, err error) {
@@ -176,6 +182,7 @@ func CreateCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInt
 }
 
 // DeleteCredentialsWaitHandler will wait for credentials deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteCredentialsWaitHandler(ctx context.Context, a APIClientCredentialsInterface, projectId, instanceId, credentialsId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {

--- a/services/resourcemanager/wait/wait.go
+++ b/services/resourcemanager/wait/wait.go
@@ -13,12 +13,14 @@ import (
 )
 
 // Interfaces needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInterface interface {
 	GetProjectExecute(ctx context.Context, containerId string) (*resourcemanager.GetProjectResponse, error)
 }
 
 // CreateProjectWaitHandler will wait for project creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateProjectWaitHandler(ctx context.Context, a APIClientInterface, containerId string) *wait.AsyncActionHandler[resourcemanager.GetProjectResponse] {
 	handler := wait.New(func() (waitFinished bool, response *resourcemanager.GetProjectResponse, err error) {
@@ -43,6 +45,7 @@ func CreateProjectWaitHandler(ctx context.Context, a APIClientInterface, contain
 }
 
 // DeleteProjectWaitHandler will wait for project deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteProjectWaitHandler(ctx context.Context, a APIClientInterface, containerId string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {

--- a/services/scf/wait/wait.go
+++ b/services/scf/wait/wait.go
@@ -15,12 +15,14 @@ import (
 const statusDeletingFailed = "deleting_failed"
 
 // Interfaces needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInterface interface {
 	GetOrganizationExecute(ctx context.Context, projectId, region, orgId string) (*scf.Organization, error)
 }
 
 // DeleteOrganizationWaitHandler will wait for Organization deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteOrganizationWaitHandler(ctx context.Context, a APIClientInterface, projectId, region, orgId string) *wait.AsyncActionHandler[scf.Organization] {
 	handler := wait.New(func() (waitFinished bool, response *scf.Organization, err error) {

--- a/services/serviceenablement/wait/wait.go
+++ b/services/serviceenablement/wait/wait.go
@@ -21,6 +21,7 @@ const (
 )
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInstanceInterface interface {
 	GetServiceStatusRegionalExecute(ctx context.Context, region, projectId, serviceId string) (*serviceenablement.ServiceStatus, error)

--- a/services/sfs/wait/wait.go
+++ b/services/sfs/wait/wait.go
@@ -42,6 +42,7 @@ const (
 )
 
 // Interfaces needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInterface interface {
 	GetResourcePoolExecute(ctx context.Context, projectId string, region string, resourcePoolId string) (*sfs.GetResourcePoolResponse, error)

--- a/services/ske/wait/wait.go
+++ b/services/ske/wait/wait.go
@@ -42,6 +42,7 @@ type APIClientClusterInterface interface {
 }
 
 // CreateOrUpdateClusterWaitHandler will wait for cluster creation or update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateOrUpdateClusterWaitHandler(ctx context.Context, a APIClientClusterInterface, projectId, region, name string) *wait.AsyncActionHandler[ske.Cluster] {
 	handler := wait.New(func() (waitFinished bool, response *ske.Cluster, err error) {
@@ -73,6 +74,7 @@ func CreateOrUpdateClusterWaitHandler(ctx context.Context, a APIClientClusterInt
 }
 
 // DeleteClusterWaitHandler will wait for cluster deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteClusterWaitHandler(ctx context.Context, a APIClientClusterInterface, projectId, region, name string) *wait.AsyncActionHandler[ske.ListClustersResponse] {
 	handler := wait.New(func() (waitFinished bool, response *ske.ListClustersResponse, err error) {
@@ -170,6 +172,7 @@ func TriggerClusterWakeupWaitHandler(ctx context.Context, a APIClientClusterInte
 }
 
 // RotateCredentialsWaitHandler will wait for credentials rotation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func RotateCredentialsWaitHandler(ctx context.Context, a APIClientClusterInterface, projectId, region, clusterName string) *wait.AsyncActionHandler[ske.Cluster] {
 	handler := wait.New(func() (waitFinished bool, response *ske.Cluster, err error) {
@@ -199,6 +202,7 @@ func RotateCredentialsWaitHandler(ctx context.Context, a APIClientClusterInterfa
 }
 
 // StartCredentialsRotationWaitHandler will wait for credentials rotation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func StartCredentialsRotationWaitHandler(ctx context.Context, a APIClientClusterInterface, projectId, region, clusterName string) *wait.AsyncActionHandler[ske.Cluster] {
 	handler := wait.New(func() (waitFinished bool, response *ske.Cluster, err error) {
@@ -224,6 +228,7 @@ func StartCredentialsRotationWaitHandler(ctx context.Context, a APIClientCluster
 }
 
 // CompleteCredentialsRotationWaitHandler will wait for credentials rotation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CompleteCredentialsRotationWaitHandler(ctx context.Context, a APIClientClusterInterface, projectId, region, clusterName string) *wait.AsyncActionHandler[ske.Cluster] {
 	handler := wait.New(func() (waitFinished bool, response *ske.Cluster, err error) {

--- a/services/sqlserverflex/wait/wait.go
+++ b/services/sqlserverflex/wait/wait.go
@@ -28,12 +28,14 @@ const (
 )
 
 // Interface needed for tests
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 type APIClientInstanceInterface interface {
 	GetInstanceExecute(ctx context.Context, projectId, instanceId, region string) (*sqlserverflex.GetInstanceResponse, error)
 }
 
 // CreateInstanceWaitHandler will wait for instance creation
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId, region string) *wait.AsyncActionHandler[sqlserverflex.GetInstanceResponse] {
 	handler := wait.New(func() (waitFinished bool, response *sqlserverflex.GetInstanceResponse, err error) {
@@ -59,6 +61,7 @@ func CreateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // UpdateInstanceWaitHandler will wait for instance update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func UpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId, region string) *wait.AsyncActionHandler[sqlserverflex.GetInstanceResponse] {
 	handler := wait.New(func() (waitFinished bool, response *sqlserverflex.GetInstanceResponse, err error) {
@@ -84,12 +87,14 @@ func UpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface
 }
 
 // PartialUpdateInstanceWaitHandler will wait for instance update
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func PartialUpdateInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId, region string) *wait.AsyncActionHandler[sqlserverflex.GetInstanceResponse] {
 	return UpdateInstanceWaitHandler(ctx, a, projectId, instanceId, region)
 }
 
 // DeleteInstanceWaitHandler will wait for instance deletion
+//
 // Deprecated: Will be removed after 2026-09-30. Move to the packages generated for each available API version instead
 func DeleteInstanceWaitHandler(ctx context.Context, a APIClientInstanceInterface, projectId, instanceId, region string) *wait.AsyncActionHandler[struct{}] {
 	handler := wait.New(func() (waitFinished bool, response *struct{}, err error) {

--- a/services/telemetryrouter/v1betaapi/wait/wait_test.go
+++ b/services/telemetryrouter/v1betaapi/wait/wait_test.go
@@ -619,5 +619,5 @@ func compareNullableTime(x, y telemetryrouter.NullableTime) bool {
 		return valX == valY
 	}
 
-	return *valX == *valY
+	return valX.Equal(*valY)
 }


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #7279

## Checklist

- [ ] Issue was linked above
- [ ] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-go/blob/783b7fa78e41d072a3ff08e246a13f1bef5aa764/services/dns/api_default.go#L9))
- [ ] Changelogs
    - [ ] Changelog in the root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/CHANGELOG.md))
    - [ ] Changelog(s) of the service(s) were adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/services/dns/CHANGELOG.md))
- [ ] VERSION file(s) of the service(s) were adjusted
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
