### PR TITLE
fix(iaas): update examples to remove deprecated waiter

### DIFF
--- a/examples/iaas/attach_volume/attach_volume.go
+++ b/examples/iaas/attach_volume/attach_volume.go
@@ -3,17 +3,20 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
+	"time"
 
+	"github.com/stackitcloud/stackit-sdk-go/core/runtime"
 	iaas "github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api"
 	"github.com/stackitcloud/stackit-sdk-go/services/iaas/v2api/wait"
 )
 
 func main() {
 	// Specify the project ID, server ID, volume ID and region
-	projectId := "PROJECT_ID" // the uuid of your STACKIT project
-	serverId := "SERVER_ID"
-	volumeId := "VOLUME_ID"
+	projectId := "66b03760-125b-4c63-9624-741e8a418c02" // the uuid of your STACKIT project
+	serverId := "cd5db3c9-c558-4147-9a27-1d5b2f0c6cc5"
+	volumeId := "2d604eb7-1444-4420-b0c9-6f5774c09d16"
 	region := "eu01"
 
 	// Create a new API client, that uses default authentication and configuration
@@ -23,32 +26,35 @@ func main() {
 		os.Exit(1)
 	}
 
+	var httpResp *http.Response
+	ctx := runtime.WithCaptureHTTPResponse(context.Background(), &httpResp)
+
 	payload := iaas.AddVolumeToServerPayload{}
-	_, err = iaasClient.DefaultAPI.AddVolumeToServer(context.Background(), projectId, region, serverId, volumeId).AddVolumeToServerPayload(payload).Execute()
+	_, err = iaasClient.DefaultAPI.AddVolumeToServer(ctx, projectId, region, serverId, volumeId).AddVolumeToServerPayload(payload).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `AddVolumeToServer`: %v\n", err)
-	} else {
-		fmt.Printf("[iaas API] Triggered attachment of volume with ID %q.\n", volumeId)
+		os.Exit(1)
 	}
+	fmt.Printf("[iaas API] Triggered attachment of volume with ID %q.\n", volumeId)
 
+	xRequestId := httpResp.Header.Get(wait.XRequestIDHeader)
 	// Wait for attachment of the volume
-	_, err = wait.AddVolumeToServerWaitHandler(context.Background(), iaasClient.DefaultAPI, projectId, region, serverId, volumeId).WaitWithContext(context.Background())
+	_, err = wait.ProjectRequestWaitHandler(ctx, iaasClient.DefaultAPI, projectId, region, xRequestId).SetSleepBeforeWait(500 * time.Millisecond).WaitWithContext(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for attachment: %v\n", err)
 		os.Exit(1)
 	}
 
-	fmt.Printf("[iaas API] Volume %q has been successfully attached to the server %s.\n", volumeId, serverId)
-
-	err = iaasClient.DefaultAPI.RemoveVolumeFromServer(context.Background(), projectId, region, serverId, volumeId).Execute()
+	err = iaasClient.DefaultAPI.RemoveVolumeFromServer(ctx, projectId, region, serverId, volumeId).Execute()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[iaas API] Error when calling `RemoveVolumeFromServer`: %v\n", err)
-	} else {
-		fmt.Printf("[iaas API] Triggered removal of attachment of volume with ID %q.\n", volumeId)
+		os.Exit(1)
 	}
+	fmt.Printf("[iaas API] Triggered removal of attachment of volume with ID %q.\n", volumeId)
 
-	// Wait for dettachment of the volume
-	_, err = wait.RemoveVolumeFromServerWaitHandler(context.Background(), iaasClient.DefaultAPI, projectId, region, serverId, volumeId).WaitWithContext(context.Background())
+	xRequestId = httpResp.Header.Get(wait.XRequestIDHeader)
+	// Wait for detachment of the volume
+	_, err = wait.ProjectRequestWaitHandler(ctx, iaasClient.DefaultAPI, projectId, region, xRequestId).SetSleepBeforeWait(500 * time.Millisecond).WaitWithContext(ctx)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "[iaas API] Error when waiting for removal of attachment of volume: %v\n", err)
 		os.Exit(1)

--- a/examples/iaas/attach_volume/attach_volume.go
+++ b/examples/iaas/attach_volume/attach_volume.go
@@ -14,9 +14,9 @@ import (
 
 func main() {
 	// Specify the project ID, server ID, volume ID and region
-	projectId := "66b03760-125b-4c63-9624-741e8a418c02" // the uuid of your STACKIT project
-	serverId := "cd5db3c9-c558-4147-9a27-1d5b2f0c6cc5"
-	volumeId := "2d604eb7-1444-4420-b0c9-6f5774c09d16"
+	projectId := "PROJECT_ID" // the uuid of your STACKIT project
+	serverId := "SERVER_ID"
+	volumeId := "VOLUME_ID"
 	region := "eu01"
 
 	// Create a new API client, that uses default authentication and configuration


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

relates to #1234

## Checklist

- [ ] Issue was linked above
- [ ] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-go/blob/783b7fa78e41d072a3ff08e246a13f1bef5aa764/services/dns/api_default.go#L9))
- [ ] Changelogs
    - [ ] Changelog in the root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/CHANGELOG.md))
    - [ ] Changelog(s) of the service(s) were adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/services/dns/CHANGELOG.md))
- [ ] VERSION file(s) of the service(s) were adjusted
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
