### PR TITLE
fix(albwaf, cost, vpn): add copyright information

### DIFF
--- a/services/albwaf/LICENSE.md
+++ b/services/albwaf/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Schwarz IT KG
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/services/cost/LICENSE.md
+++ b/services/cost/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Schwarz IT KG
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/services/vpn/LICENSE.md
+++ b/services/vpn/LICENSE.md
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2026 Schwarz IT KG
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description
Copyright information was missing in the license of some services. 

## Checklist

- [ ] Issue was linked above
- [ ] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-go/blob/783b7fa78e41d072a3ff08e246a13f1bef5aa764/services/dns/api_default.go#L9))
- [ ] Changelogs
    - [ ] Changelog in the root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/CHANGELOG.md))
    - [ ] Changelog(s) of the service(s) were adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/services/dns/CHANGELOG.md))
- [ ] VERSION file(s) of the service(s) were adjusted
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
