### PR TITLE
fix: remove local replace in auditlog example

### DIFF
--- a/examples/auditlog/go.mod
+++ b/examples/auditlog/go.mod
@@ -2,9 +2,6 @@ module auditlog
 
 go 1.25
 
-// This is not needed in production. This is only here to point the golangci linter to the local version instead of the last release on GitHub.
-replace github.com/stackitcloud/stackit-sdk-go/services/auditlog => ../../services/auditlog
-
 require (
 	github.com/stackitcloud/stackit-sdk-go/core v0.26.0
 	github.com/stackitcloud/stackit-sdk-go/services/auditlog v0.5.0

--- a/examples/auditlog/go.sum
+++ b/examples/auditlog/go.sum
@@ -6,3 +6,5 @@ github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/stackitcloud/stackit-sdk-go/core v0.26.0 h1:jQEb9gkehfp6VCP6TcYk7BI10cz4l0KM2L6hqYBH2QA=
 github.com/stackitcloud/stackit-sdk-go/core v0.26.0/go.mod h1:WU1hhxnjXw2EV7CYa1nlEvNpMiRY6CvmIOaHuL3pOaA=
+github.com/stackitcloud/stackit-sdk-go/services/auditlog v0.5.0 h1:xuxFUnDY0yI2UQWy5SPMN+u29FQ9maGNupsW7xS7q8k=
+github.com/stackitcloud/stackit-sdk-go/services/auditlog v0.5.0/go.mod h1:g7j7jLGJ16j0CPIHrpt+brXLl+JckETubF9/Jnw+O6Y=


### PR DESCRIPTION
## Description

<!-- **Please link some issue here describing what you are trying to achieve.**

In case there is no issue present for your PR, please consider creating one.
At least please give us some description what you are trying to achieve and why your change is needed. -->

Generator fails because auditlog is missing as generated service and it makes the replace is invalid

relates to https://github.com/stackitcloud/stackit-api-specifications/commit/7e686e8b86adf22cd2493eb1986cf6ec729d69e9 and https://github.com/stackitcloud/stackit-api-specifications/actions/runs/29498400474/job/87620838975#step:8:1739

## Checklist

- [ ] Issue was linked above
- [ ] **No generated code was adjusted manually** (check [comments in file header](https://github.com/stackitcloud/stackit-sdk-go/blob/783b7fa78e41d072a3ff08e246a13f1bef5aa764/services/dns/api_default.go#L9))
- [ ] Changelogs
    - [ ] Changelog in the root directory was adjusted (see [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/CHANGELOG.md))
    - [ ] Changelog(s) of the service(s) were adjusted (see e.g. [here](https://github.com/stackitcloud/stackit-sdk-go/blob/f1e375a38064f798821d22a951bc74ca8a9c8845/services/dns/CHANGELOG.md))
- [ ] VERSION file(s) of the service(s) were adjusted
- [ ] Code format was applied: `make fmt`
- [ ] Examples were added / adjusted (see `examples/` directory)
- [ ] Unit tests got implemented or updated
- [x] Unit tests are passing: `make test` (will be checked by CI)
- [x] No linter issues: `make lint` (will be checked by CI)  
